### PR TITLE
[FIXED  JENKINS-28570] Allow users with Extended Read permission to read modifications in Job configurations.

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -66,7 +66,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * jobs.
      */
     public final String getIconFileName() {
-        if (!hasConfigurePermission()) {
+        if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
             return null;
         }
         if (project instanceof TopLevelItem) {
@@ -87,7 +87,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
      */
     public final List<ConfigInfo> getJobConfigs() throws IOException {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final ArrayList<ConfigInfo> configs = new ArrayList<ConfigInfo>();
         final ArrayList<HistoryDescr> values = new ArrayList<HistoryDescr>(
                 getHistoryDao().getRevisions(project.getConfigFile()).values());
@@ -148,7 +151,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      *             string.
      */
     public final String getFile() throws IOException {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final String timestamp = getRequestParameter("timestamp");
         final XmlFile xmlFile = getOldConfigXml(timestamp);
         return xmlFile.asString();
@@ -181,6 +187,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
         return getAccessControlledObject().hasPermission(Item.CONFIGURE);
     }
 
+    public boolean hasReadExtensionPermission() {
+        return getAccessControlledObject().hasPermission(Item.EXTENDED_READ);
+    }
+
     /**
      * Used in the Difference jelly only. Returns one of the two timestamps that
      * have been passed to the Difference page as parameter. timestampNumber
@@ -191,7 +201,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @return the timestamp as String.
      */
     public final String getTimestamp(int timestampNumber) {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         return this.getRequestParameter("timestamp" + timestampNumber);
     }
 
@@ -219,7 +232,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @return the operation as String.
      */
     public final String getOperation(int timestampNumber) {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         return getHistoryDao().getRevisions(this.project.getConfigFile())
                 .get(getTimestamp(timestampNumber)).getOperation();
     }
@@ -234,7 +250,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @return the timestamp of the next entry as String.
      */
     public final String getNextTimestamp(int timestampNumber) {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final String timestamp = this.getRequestParameter("timestamp" + timestampNumber);
         final SortedMap<String, HistoryDescr> revisions = getHistoryDao().getRevisions(this.project.getConfigFile());
         final Iterator<Entry<String, HistoryDescr>> itr = revisions.entrySet().iterator();
@@ -257,7 +276,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @return the timestamp of the preious entry as String.
      */
     public final String getPrevTimestamp(int timestampNumber) {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final String timestamp = this.getRequestParameter("timestamp" + timestampNumber);
         final SortedMap<String, HistoryDescr> revisions = getHistoryDao().getRevisions(this.project.getConfigFile());
         final Iterator<Entry<String, HistoryDescr>> itr = revisions.entrySet().iterator();
@@ -282,7 +304,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @throws IOException If diff doesn't work or xml files can't be read.
      */
     public final List<Line> getLines() throws IOException {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final String timestamp1 = getRequestParameter("timestamp1");
         final String timestamp2 = getRequestParameter("timestamp2");
 
@@ -305,7 +330,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @return The config file as XmlFile.
      */
     private XmlFile getOldConfigXml(String timestamp) {
-        checkConfigurePermission();
+        if(!hasConfigurePermission() && !hasReadExtensionPermission()) {
+            checkConfigurePermission();
+            return null;
+        }
         final XmlFile oldRevision = getHistoryDao().getOldRevision(project, timestamp);
         if (oldRevision.getFile() != null) {
             return oldRevision;

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -23,9 +23,13 @@
                   <tr>
                     <td class="pane-header" initialSortDir="up" align="left">${%Date}</td>
                     <td class="pane-header" align="left">${%Operation}</td>
-                    <td class="pane-header" align="left">${%User}</td>
+                    <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                      <td class="pane-header" align="left">${%User}</td>
+                    </j:if>
                     <td class="pane-header" align="left">${%Show File}</td>
-                    <td class="pane-header" align="left">${%Restore old config}</td>
+                    <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                      <td class="pane-header" align="left">${%Restore old config}</td>
+                    </j:if>
                     <td class="pane-header" align="center" style="border-left: solid 1px #bbb;">${%File A}</td>
                     <td class="pane-header" align="center" style="border-left: solid 1px #bbb;">${%File B}</td>
                   </tr>
@@ -35,7 +39,9 @@
                     <tr>
                       <td>${config.date}</td>
                       <td>${config.operation}</td>
-                      <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                      <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                        <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                      </j:if>
                       <td>
                         <j:set var="fileMissing" value="${!config.hasConfig()}"/>
                         <j:if test="${!fileMissing}">
@@ -48,12 +54,14 @@
                           </a>
                         </j:if>
                       </td>
-                      <td><j:if test="${configNr > 1 and !fileMissing}">
-							<a id="restore${configNr}" href="restoreQuestion?timestamp=${config.getDate()}">
-								<img src="${resURL}/plugin/jobConfigHistory/img/restore.png" alt="${%Restore}" />
-							</a>
-                          </j:if>
-                      </td>
+                      <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                          <td><j:if test="${configNr > 1 and !fileMissing}">
+                                <a id="restore${configNr}" href="restoreQuestion?timestamp=${config.getDate()}">
+                                    <img src="${resURL}/plugin/jobConfigHistory/img/restore.png" alt="${%Restore}" />
+                                </a>
+                              </j:if>
+                          </td>
+                      </j:if>
                       <j:if test="${configNr == 2 and fileMissing}">
                         <j:set var="offsetIfFileMissing" value="1"/>
                       </j:if>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -5,7 +5,7 @@
       <h1>${%Job Configuration Difference}</h1>
       <div>
         <j:choose>
-          <j:when test="${!it.hasConfigurePermission()}">
+          <j:when test="${!it.hasConfigurePermission() and !it.hasReadExtensionPermission()}">
             ${%No permission to view config history}
           </j:when>
           <j:when test="${it.getJobConfigs().size() == 0}">
@@ -37,27 +37,35 @@
                     <td colspan="2">
                       <table style="width:100%; border-collapse: collapse;">
                         <tr>
-                          <td><b>User:</b> <a style="margin-left: 2px;" href="${rootURL}/user/${it.getUser(1)}">${it.getUser(1)}</a> </td>
-                          <td align="right">
-                            <f:form method="post" action="forwardToRestoreQuestion?timestamp=${request.getParameter('timestamp1')}" name="forward">
-                              <f:submit value="${%Restore this configuration}" />
-                            </f:form>
-                          </td>
+                          <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                            <td><b>User:</b> <a style="margin-left: 2px;" href="${rootURL}/user/${it.getUser(1)}">${it.getUser(1)}</a> </td>
+                          </j:if>
+                          <j:if test="${it.hasConfigurePermission()}">
+                            <td align="right">
+                              <f:form method="post" action="forwardToRestoreQuestion?timestamp=${request.getParameter('timestamp1')}" name="forward">
+                                <f:submit value="${%Restore this configuration}" />
+                              </f:form>
+                            </td>
+                          </j:if>
                         </tr>
                       </table>
                     </td>
-                    <td colspan="2">  
+                    <td colspan="2">
                       <table style="width:100%; border-collapse: collapse;">
                         <tr>
-                          <td><b>User:</b> <a style="margin-left: 2px;" href="${rootURL}/user/${it.getUser(2)}">${it.getUser(2)}</a> </td>
-                          <td align="right">
-                            <f:form method="post" action="forwardToRestoreQuestion?timestamp=${request.getParameter('timestamp2')}" name="forward">
-                              <f:submit value="${%Restore this configuration}" />
-                            </f:form>
-                          </td>
+                          <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                            <td><b>User:</b> <a style="margin-left: 2px;" href="${rootURL}/user/${it.getUser(2)}">${it.getUser(2)}</a> </td>
+                          </j:if>
+                          <j:if test="${it.hasConfigurePermission()}">
+                            <td align="right">
+                              <f:form method="post" action="forwardToRestoreQuestion?timestamp=${request.getParameter('timestamp2')}" name="forward">
+                                <f:submit value="${%Restore this configuration}" />
+                              </f:form>
+                            </td>
+                          </j:if>
                         </tr>
                       </table>
-                    </td>             
+                    </td>
                   </tr>
                 </thead>
                 <tbody style="outline: 1pt solid #B2B2B2;">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -44,7 +44,7 @@
           <j:when test="${!it.hasConfigurePermission() and (filter == 'system' || filter == null)}">
             ${%No permission to view system changes}
           </j:when>
-          <j:when test="${!it.hasJobConfigurePermission()}">
+          <j:when test="${!it.hasJobConfigurePermission() and !it.hasReadExtensionPermission()}">
             ${%No permission to view config history}
           </j:when>
           <j:when test="${configs.size() == 0}">
@@ -67,7 +67,9 @@
                     </j:otherwise>
                   </j:choose>
                   <td class="pane-header" align="left">${%Operation}</td>
-                  <td class="pane-header" align="left">${%User}</td>
+                  <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                    <td class="pane-header" align="left">${%User}</td>
+                  </j:if>
                   <td class="pane-header" align="left">${%File(raw)}</td>
                   <j:if test="${filter == 'deleted'}">
                     <td class="pane-header" align="left">${%Restore project}</td>
@@ -96,7 +98,9 @@
                       </j:otherwise>
                     </j:choose>
                     <td>${config.operation}</td>
-                    <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                    <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                      <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                    </j:if>
                     <td>
                       <!-- TODO check whether job has a JobConfigHistoryProjectAction before hyperlinking -->
                       <a href="${it.createLinkToFiles(config,'xml')}">
@@ -110,9 +114,11 @@
                     <j:if test="${filter == 'deleted'}">
                       <td>
                         <j:if test="${it.getLastAvailableConfigXml(config.getJob()) != null}">
-						  <a id="restore" href="restoreQuestion?name=${config.getJob()}">
+                          <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
+                            <a id="restore" href="restoreQuestion?name=${config.getJob()}">
 							<img src="${resURL}/plugin/jobConfigHistory/img/restore.png" alt="${%Restore}" />
-						  </a>
+						    </a>
+                          </j:if>
 						</j:if>
                       </td>
                     </j:if>


### PR DESCRIPTION
Users with EXTENDED_READ permission should be able to see Job configuration modifications. Sometimes Jenkins admins might want that their users are able to see the differences so they can understand why a specific build is failing.

However, users with this permission shouldn't be able to see config modification, neither to restore a job configuration

@reviewbybees