### PR TITLE
[JENKINS-25654] Do not show restore button if there are no configs available.

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -102,7 +102,7 @@
 		       	</j:if>
               </f:form>
             </div>
-            <j:if test="${isDeleted}">
+            <j:if test="${isDeleted and configs.size() > 1}">
               <f:form method="post" action="forwardToRestoreQuestion?name=${name}" name="forward">
                 <div align="right">
                   <f:submit value="${%Restore project}" />


### PR DESCRIPTION
Hotfix for JENKINS-25654.

We can't restore a job when there's no stored config file available.
When a job gets deleted, we can't save a config file.
If a job is enabled and get's deleted, jenkins first deactivates the job and then deletes ist. So in this case we have a config file.
But if a job is deactivated and the job gets deleted, jenkins doesn't deactivate it (because it is already) and deletes it directly. So in the case when a job is deactivated, JobConfigHistory gets installed, no more configuration for this job get performed and the job gets deleted, we don't have any config file we could restore.

A workaround for this case is, that we don't show the restore button, when there's no config file available.