### PR TITLE
Fixed url in ciManagement (pom.xml).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </scm>
     <ciManagement>
         <system>Jenkins</system>
-        <url>http://huschteguzzel.de/hudson/job/jenkinsci-jobConfigHistory-plugin/</url>
+        <url>https://jenkins.ci.cloudbees.com/job/plugins/job/jobConfigHistory-plugin/</url>
     </ciManagement>
     <licenses>
         <license>


### PR DESCRIPTION
Huschteguzzle doesn't exist anymore. Changed url to cloudbees CI.