### PR TITLE
Changing computer display name from slave to agent

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
@@ -80,7 +80,7 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
 
     @Override
     public final String getDisplayName() {
-        return Messages.slaveDisplayName();
+        return Messages.agentDisplayName();
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/index.jelly
@@ -1,8 +1,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="Slave Configuration History">
+  <l:layout title="Agent Configuration History">
     <st:include it="${it.slave.toComputer()}" page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${%Slave Configuration History}</h1>
+      <h1>${%Agent Configuration History}</h1>
       <h2>${it.getSlave().getNodeName()}</h2>
       <div>
       <script type="text/javascript">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/restoreQuestion.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/restoreQuestion.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="Slave Configuration History" css="/plugin/jobConfigHistory/diff_highlight.css">
+  <l:layout title="Agent Configuration History" css="/plugin/jobConfigHistory/diff_highlight.css">
     <st:include it="${it.slave.toComputer()}" page="sidepanel.jelly" />
     <l:main-panel>
     <j:set var="timestamp" value="${request.getParameter('timestamp')}" />

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -2,14 +2,14 @@
   <l:layout title="Job Configuration History" css="/plugin/jobConfigHistory/diff_highlight.css">
     <st:include it="${app}" page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${%Slave Configuration Difference}</h1>
+      <h1>${%Agent Configuration Difference}</h1>
       <div>
         <j:choose>
           <j:when test="${!it.hasConfigurePermission()}">
             ${%No permission to view config history}
           </j:when>
           <j:when test="${it.getSlaveConfigs().size() == 0}">
-              ${%No slave configuration history available}
+              ${%No agent configuration history available}
           </j:when>
           <j:otherwise>
             <div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/Messages.properties
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/Messages.properties
@@ -1,5 +1,5 @@
 displayName=Job Config History
-slaveDisplayName=Slave Config History
+agentDisplayName=Agent Config History
 
 ConfigHistoryListenerHelper.CREATED=Created
 ConfigHistoryListenerHelper.RENAMED=Renamed

--- a/src/test/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryActionTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryActionTest.java
@@ -1,0 +1,35 @@
+package hudson.plugins.jobConfigHistory;
+
+import hudson.model.Slave;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+
+/**
+ *
+ * @author Greg Fogelberg
+ */
+public class ComputerConfigHistoryActionTest {
+
+    private final Slave agentMock = mock(Slave.class);
+
+    /**
+     * Test of getDisplayName method, of class ComputerConfigHistoryAction.
+     */
+    @Test
+    public void testGetDisplayName() {
+        ComputerConfigHistoryAction sut = new ComputerConfigHistoryActionImpl();
+        String expResult = "Agent Config History";
+        String result = sut.getDisplayName();
+        assertEquals(expResult, result);
+    }
+
+    public class ComputerConfigHistoryActionImpl extends ComputerConfigHistoryAction {
+
+        public ComputerConfigHistoryActionImpl() {
+            super(agentMock);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR will change references to 'Slave' to be 'Agent' to align with Jenkins 2.0 nomenclature. Includes Unit Test for ComputerConfigHistoryAction.getDisplayName()

Tested Locally and see 'Slave Config History' updated to 'Agent Config History' and 'Agent Configuration Difference'
![screen shot 2017-01-04 at 1 43 58 pm](https://cloud.githubusercontent.com/assets/588833/21660559/bf63b66e-d284-11e6-8fdd-aef1f2697813.png)
![screen shot 2017-01-04 at 1 50 43 pm](https://cloud.githubusercontent.com/assets/588833/21660575/ca3598aa-d284-11e6-8663-ea68662e5c6a.png)

Unit test passing as well:
```
Running hudson.plugins.jobConfigHistory.ComputerConfigHistoryActionTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.415 sec - in hudson.plugins.jobConfigHistory.ComputerConfigHistoryActionTest
```