### PR TITLE
Also exclude files from the lockable resources plugin

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
@@ -56,7 +56,7 @@ public final class JobConfigHistoryConsts {
 	public static final String HISTORY_FILE = "history.xml";
 
 	/** Default regexp pattern of configuration files not to save. */
-	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats";
+	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\.xml";
 
 	/** Format for timestamped dirs. */
 	public static final String ID_FORMATTER = "yyyy-MM-dd_HH-mm-ss";


### PR DESCRIPTION
The file org.jenkins.plugins.lockableresources.LockableResourcesManager.xml
is frequently updated: every time a resource is locked or unlocked. On
a large Jenkins instance with the lockable resources plugin installed, we 
saw major slowdown from tracking history on this file.