### PR TITLE
Fix root URL

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
@@ -201,7 +201,7 @@ public class JobConfigBadgeAction implements BuildBadgeAction, RunAction2 {
 	 * @return root-URL of Jenkins.
 	 */
 	String getRootUrl() {
-		return Jenkins.getInstance().getRootUrlFromRequest();
+		return Jenkins.getInstance().getRootUrl();
 	}
 
 	/**


### PR DESCRIPTION
Uses the value from configuration, then falls back to `getRootUrlFromRequest()`.