### PR TITLE
Add Jenkinsfile to build plugin on https://ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build on ci.jenkins.io; see https://github.com/jenkins-infra/pipeline-library
+buildPlugin()


### PR DESCRIPTION
Since builds on Cloudbees CI are disabled, I think it is good to build this plugin on Jenkins own CI. I've added this Jenkinsfile that should do the job, take a look at this example: https://github.com/jenkinsci/android-lint-plugin/blob/master/Jenkinsfile