### PR TITLE
Use canonical user identify in case change initiator is unknown

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -153,15 +153,10 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 			final File timestampedDir, final String operation,
 			final String newName, String oldName) throws IOException {
 		oldName = ((oldName == null) ? "" : oldName);
-		final String user;
-		final String userId;
-		if (currentUser != null) {
-			user = currentUser.getFullName();
-			userId = currentUser.getId();
-		} else {
-			user = "Anonym";
-			userId = Messages.ConfigHistoryListenerHelper_anonymous();
-		}
+
+		// Mimicking User.getUnknown() that can not be instantiated here as a lot of tests are run without Jenkins
+		final String user = currentUser != null ? currentUser.getFullName() : "unknown";
+		final String userId = currentUser != null ? currentUser.getId() : "unknown";
 
 		final XmlFile historyDescription = getHistoryXmlFile(timestampedDir);
 		final HistoryDescr myDescr = new HistoryDescr(user, userId, operation,

--- a/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
@@ -202,7 +202,7 @@ public class FileHistoryDaoTest {
 	 */
 	@Test
 	public void testCreateHistoryXmlFileAnonym() throws Exception {
-		testCreateHistoryXmlFile(sutWithoutUserAndDuplicateHistory, "Anonym");
+		testCreateHistoryXmlFile(sutWithoutUserAndDuplicateHistory, "unknown");
 	}
 
 	private void testCreateHistoryXmlFile(FileHistoryDao sut,


### PR DESCRIPTION
Plugin currently reports the change that was done without known identity to be done by `Anonym`/`anonymous` user.

Note the duality is actually visible in UI as commit list uses the id (`anonymous`) while commit details uses the full name (`Anonym`). Both are presented as clickable links pointing to 2 different user accounts so it is quite confusing. Not to mention it causes 2 user accounts to be created for no good reason.

Jenkins already have an identity dedicated to situations like this so switching to use that instead.