### PR TITLE
[JENKINS-45821] Add the MilestoneStep file by default

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
@@ -56,7 +56,7 @@ public final class JobConfigHistoryConsts {
 	public static final String HISTORY_FILE = "history.xml";
 
 	/** Default regexp pattern of configuration files not to save. */
-	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\.xml";
+	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\.xml|MilestoneStep\\.xml";
 
 	/** Format for timestamped dirs. */
 	public static final String ID_FORMATTER = "yyyy-MM-dd_HH-mm-ss";


### PR DESCRIPTION
The file `org.jenkinsci.plugins.pipeline.milestone.MilestoneStep.xml`
is updated every time milestone is reached in a pipeline build. This could cause major slowdown on large instances as well as disk space issue. (seen a use case where the history of that file would reach gigabytes...)