### PR TITLE
[WiP][JENKINS-41844] Make hasDuplicateHistory efficient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <artifactId>jobConfigHistory</artifactId>
     <packaging>hpi</packaging>
-    <version>2.18.4-SNAPSHOT</version>
+    <version>2.20-SNAPSHOT</version>
 
     <name>Jenkins Job Configuration History Plugin</name>
     <description>Saves copies of job, node and system configurations.</description>
@@ -44,7 +44,7 @@
     
     <issueManagement>
         <system>JIRA</system>
-        <url>http://issues.jenkins-ci.org/secure/IssueNavigator.jspa?reset=true&amp;jqlQuery=project+%3D+JENKINS+AND+status+in+%28Open%2C+%22In+Progress%22%2C+Reopened%29+AND+component+%3D+%27jobconfighistory-plugin%27</url>
+        <url>https://issues.jenkins-ci.org/issues/?jql=project %3D Jenkins AND status in (Open, "In Progress", Reopened) AND component %3D jobconfighistory-plugin</url>
     </issueManagement>
     
     <scm>
@@ -108,14 +108,19 @@
     </developers>
 
     <properties>
-    	<jenkins-test-harness.version>1.554.1</jenkins-test-harness.version>
         <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
         <maven-hpi-plugin.injectedTestName>InjectedIT</maven-hpi-plugin.injectedTestName>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <jdepend-maven-plugin.version>2.9.1</jdepend-maven-plugin.version>
+        <java.level>8</java.level>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.6.2</version>
+        </dependency>
         <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -24,6 +24,7 @@
 package hudson.plugins.jobConfigHistory;
 
 import static java.util.logging.Level.FINEST;
+import static org.kohsuke.stapler.Facet.LOGGER;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -45,6 +46,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import org.apache.commons.io.FileUtils;
 
 import hudson.Extension;
@@ -243,6 +246,12 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 			timestamp = new GregorianCalendar();
 			f = new File(itemHistoryDir,
 					getIdFormatter().format(timestamp.getTime()));
+			// Create a symlink pointing to the last change
+			try {
+				Util.createSymlink(itemHistoryDir, f.toPath().toString(), "lastHistory", TaskListener.NULL);
+			} catch (InterruptedException e) {
+				LOGGER.log(Level.WARNING, String.format("Could not create symblink for %s",  itemHistoryDir.toPath()), e);
+			}
 			if (f.isDirectory()) {
 				LOG.log(Level.FINE, "clash on {0}, will wait a moment", f);
 				try {

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -33,6 +33,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -404,7 +406,9 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 				final XmlFile historyXml = getHistoryXmlFile(historyDir);
 				final LazyHistoryDescr historyDescription = new LazyHistoryDescr(
 						historyXml);
-				map.put(historyDir.getName(), historyDescription);
+				if (!Files.isSymbolicLink(Paths.get(historyDir.getAbsolutePath()))) {
+					map.put(historyDir.getName(), historyDescription);
+				}
 			}
 			return map;
 		}

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -56,7 +56,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import org.apache.commons.io.FileUtils;
 
 import hudson.Extension;

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -249,12 +249,6 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 			timestamp = new GregorianCalendar();
 			f = new File(itemHistoryDir,
 					getIdFormatter().format(timestamp.getTime()));
-			// Create a symlink pointing to the last change
-			try {
-				Util.createSymlink(itemHistoryDir, f.toPath().toString(), "lastHistory", TaskListener.NULL);
-			} catch (InterruptedException e) {
-				LOGGER.log(Level.WARNING, String.format("Could not create symblink for %s",  itemHistoryDir.toPath()), e);
-			}
 			if (f.isDirectory()) {
 				LOG.log(Level.FINE, "clash on {0}, will wait a moment", f);
 				try {
@@ -272,6 +266,13 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 		if (!(f.mkdirs() || f.exists())) {
 			throw new RuntimeException("Could not create rootDir " + f);
 		}
+		// Create a symlink pointing to the last change
+		try {
+			Util.createSymlink(itemHistoryDir, f.toPath().toString(), "lastHistory", TaskListener.NULL);
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.WARNING, String.format("Could not create symblink for %s",  itemHistoryDir.toPath()), e);
+		}
+
 		return f;
 	}
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -704,7 +704,6 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 	 */
 	boolean hasDuplicateHistory(final XmlFile xmlFile) {
 		boolean isDuplicated = false;
-<<<<<<< HEAD
 		XmlFile lastRevision = null;
 
 		// Frist, we try to obtain the latest revision from the symblink
@@ -729,14 +728,6 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 		}
 
 		if (lastRevision != null) {
-=======
-		final ArrayList<String> timeStamps = new ArrayList<String>(
-			getRevisions(xmlFile).keySet());
-		if (!timeStamps.isEmpty()) {
-			Collections.sort(timeStamps, Collections.reverseOrder());
-			final XmlFile lastRevision = getOldRevision(xmlFile,
-				timeStamps.get(0));
->>>>>>> origin
 			try {
 				if (xmlFile.asString().equals(lastRevision.asString())) {
 					isDuplicated = true;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -257,6 +257,33 @@ public class JobConfigHistory extends Plugin {
 	}
 
 	/**
+	 * Used by the configuration page.
+	 *
+	 * @return The default max number of history entries to keep
+	 */
+	public String getDefaultMaxHistoryEntries() {
+		return JobConfigHistoryConsts.DEFAULT_MAX_HISTORY_ENTRIES;
+	}
+
+	/**
+	 * Used by the configuration page.
+	 *
+	 * @return The default max number of days to keep history entries
+	 */
+	public String getDefaultMaxDaysToKeepEntries() {
+		return JobConfigHistoryConsts.DEFAULT_MAX_DAYS_TO_KEEP_ENTRIES;
+	}
+
+	/**
+	 * Used by the configuration page.
+	 *
+	 * @return The default max number of history entries to show per page
+	 */
+	public String getDefaultMaxEntriesPerPage() {
+		return JobConfigHistoryConsts.DEFAULT_MAX_ENTRIES_PER_PAGE;
+	}
+
+	/**
 	 * @return true if we should save 'system' configurations.
 	 */
 	public boolean getSaveModuleConfiguration() {

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
@@ -29,14 +29,7 @@ package hudson.plugins.jobConfigHistory;
  * @author Stefan Brausch
  */
 public final class JobConfigHistoryConsts {
-
-	/**
-	 * Holder for constants.
-	 */
-	private JobConfigHistoryConsts() {
-		// Holder for constants
-	}
-
+	
 	/** Path to the jobConfigHistory base. */
 	public static final String URLNAME = "jobConfigHistory";
 
@@ -56,7 +49,7 @@ public final class JobConfigHistoryConsts {
 	public static final String HISTORY_FILE = "history.xml";
 
 	/** Default regexp pattern of configuration files not to save. */
-	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\.xml";
+	public static final String DEFAULT_EXCLUDE = "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\.xml|MilestoneStep\\.xml";
 
 	/** Format for timestamped dirs. */
 	public static final String ID_FORMATTER = "yyyy-MM-dd_HH-mm-ss";
@@ -69,4 +62,11 @@ public final class JobConfigHistoryConsts {
 
 	/** Default maximum number of days to keep entries. */
 	public static final String DEFAULT_MAX_DAYS_TO_KEEP_ENTRIES = "20";
+
+	/**
+	 * Holder for constants.
+	 */
+	private JobConfigHistoryConsts() {
+		// Holder for constants
+	}
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryConsts.java
@@ -60,4 +60,13 @@ public final class JobConfigHistoryConsts {
 
 	/** Format for timestamped dirs. */
 	public static final String ID_FORMATTER = "yyyy-MM-dd_HH-mm-ss";
+
+	/** Default maximum number of configuration history entries to keep. */
+	public static final String DEFAULT_MAX_HISTORY_ENTRIES = "1000";
+
+	/** Default maximum number of history entries per site to show. */
+	public static final String DEFAULT_MAX_ENTRIES_PER_PAGE = "30";
+
+	/** Default maximum number of days to keep entries. */
+	public static final String DEFAULT_MAX_DAYS_TO_KEEP_ENTRIES = "20";
 }

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
@@ -7,15 +7,15 @@
 	</f:entry>
     <f:advanced>
       <f:entry title="${%Max number of history entries to keep}" help="/plugin/jobConfigHistory/help/help-maxHistoryEntries.html">
-        <f:textbox name="maxHistoryEntries" value="${it.maxHistoryEntries}"
+        <f:textbox name="maxHistoryEntries" value="${it.maxHistoryEntries}" default="${it.defaultMaxHistoryEntries}"
            checkUrl="'${rootURL}/plugin/jobConfigHistory/checkMaxHistoryEntries?value='+escape(this.value)"/>
       </f:entry>
       <f:entry title="${%Max number of days to keep history entries}" help="/plugin/jobConfigHistory/help/help-maxDaysToKeepEntries.html">
-        <f:textbox name="maxDaysToKeepEntries" value="${it.maxDaysToKeepEntries}"
+        <f:textbox name="maxDaysToKeepEntries" value="${it.maxDaysToKeepEntries}" default="${it.defaultMaxDaysToKeepEntries}"
            checkUrl="'${rootURL}/plugin/jobConfigHistory/checkMaxDaysToKeepEntries?value='+escape(this.value)"/>
       </f:entry>
       <f:entry title="${%Max number of history entries to show per page}" help="/plugin/jobConfigHistory/help/help-maxEntriesPerPage.html">
-        <f:textbox name="maxEntriesPerPage" value="${it.maxEntriesPerPage}"
+        <f:textbox name="maxEntriesPerPage" value="${it.maxEntriesPerPage}" default="${it.defaultMaxEntriesPerPage}"
            checkUrl="'${rootURL}/plugin/jobConfigHistory/checkMaxEntriesPerPage?value='+escape(this.value)"/>
       </f:entry>
       <f:entry title="${%System configuration exclude file pattern}" help="/plugin/jobConfigHistory/help/help-excludePattern.html">

--- a/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
@@ -126,7 +126,7 @@ public class FileHistoryDaoTest {
 		sutWithoutUserAndDuplicateHistory.createNewHistoryEntry(test1Config,
 				"foo", null, null);
 		final int newLength = getHistoryLength();
-		assertEquals(6, newLength);
+		assertEquals(7, newLength);
 	}
 
 	/**
@@ -295,7 +295,7 @@ public class FileHistoryDaoTest {
 	@Test
 	public void testSaveItem_XmlFileDuplicate() {
 		sutWithoutUserAndDuplicateHistory.saveItem(test1Config);
-		assertEquals(6, getHistoryLength());
+		assertEquals(7, getHistoryLength());
 	}
 
 	private int getHistoryLength() {
@@ -326,7 +326,7 @@ public class FileHistoryDaoTest {
 				"NewName");
 		final File newHistoryDir = new File(historyRoot, "jobs/" + newName);
 		assertTrue(newHistoryDir.exists());
-		assertEquals(6, newHistoryDir.list().length);
+		assertEquals(7, newHistoryDir.list().length);
 	}
 
 	/**

--- a/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
@@ -44,6 +44,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -267,7 +269,15 @@ public class FileHistoryDaoTest {
 		final File historyDir = new File(jenkinsHome,
 				"config-history/jobs/MyTest");
 		assertTrue(historyDir.exists());
-		assertEquals(1, historyDir.list().length);
+
+		final File lastHistory = new File(jenkinsHome,
+				"config-history/jobs/MyTest/lastHistory");
+
+		Files.isSymbolicLink(Paths.get(lastHistory.getAbsolutePath()));
+		assertEquals(2, historyDir.list().length);
+
+
+
 	}
 
 	/**
@@ -680,7 +690,7 @@ public class FileHistoryDaoTest {
 		sutWithUserAndNoDuplicateHistory.createNewNode(mockedNode);
 		File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
 		File revisions = new File(file, "slave1");
-		assertEquals("Slave1 should have only one save history.", 1,
+		assertEquals("Slave1 should have only one save history.", 2,
 				revisions.list().length);
 		File config = new File(revisions.listFiles()[0], "config.xml");
 		assertTrue("File config.xml should be saved.", config.exists());
@@ -787,7 +797,7 @@ public class FileHistoryDaoTest {
 		File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
 		File revisions = new File(file, "slave1");
 		sutWithUserAndNoDuplicateHistory.saveNode(mockedNode);
-		assertEquals("New revision should be saved.", 1,
+		assertEquals("New revision should be saved.", 2,
 				revisions.list().length);
 	}
 


### PR DESCRIPTION
This is the easiest part to fix [JENKINS-41844](https://issues.jenkins-ci.org/browse/JENKINS-41844)

With the default values on this PR it seems `hasDuplicateHistory ` continue working properly even on slow filesystems

More PRs will come to fix JENKINS-41844