### PR TITLE
Hide version changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>
             <version>1.2.1</version>

--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
@@ -391,8 +391,7 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
 	 * @throws IOException
 	 * 		If XML file can't be read
 	 */
-	public final void doToggleShowHideVersionDiffs(StaplerRequest req,
-												   StaplerResponse rsp) throws IOException {
+	public final void doToggleShowHideVersionDiffs(StaplerRequest req, StaplerResponse rsp) throws IOException {
 		//simply reload current page.
 		final String timestamp1 = req.getParameter("timestamp1");
 		final String timestamp2 = req.getParameter("timestamp2");

--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -302,19 +303,22 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
 		return xmlFile.asString();
 	}
 
-	/**
-	 * Takes the two timestamp request parameters and returns the diff between
-	 * the corresponding config files of this slave as a list of single lines.
-	 *
-	 * @return Differences between two config versions as list of lines.
-	 * @throws IOException
-	 *             If diff doesn't work or xml files can't be read.
-	 */
-	public final List<Line> getLines() throws IOException {
+	public final List<Line> getLines(boolean useRegex) throws IOException {
 		checkConfigurePermission();
 		final String timestamp1 = getRequestParameter("timestamp1");
 		final String timestamp2 = getRequestParameter("timestamp2");
-		return getLines(getOldConfigXml(timestamp1), getOldConfigXml(timestamp2));
+
+		final XmlFile configXml1 = getOldConfigXml(timestamp1);
+		final String[] configXml1Lines = configXml1.asString().split("\\n");
+		final XmlFile configXml2 = getOldConfigXml(timestamp2);
+		final String[] configXml2Lines = configXml2.asString().split("\\n");
+
+		//compute the diff with respect to ignoredLinesPattern if useRegex == true
+		final String diffAsString = getDiffAsString(configXml1.getFile(),
+				configXml2.getFile(), configXml1Lines, configXml2Lines, useRegex);
+
+		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
+		return getDiffLines(diffLines);
 	}
 
 	/**
@@ -385,6 +389,29 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
 			StaplerResponse rsp) throws IOException {
 		final String timestamp = req.getParameter("timestamp");
 		rsp.sendRedirect("restoreQuestion?timestamp=" + timestamp);
+	}
+
+	/**
+	 * Action when 'Show / hide Version Changes' button in showDiffFiles.jelly is pressed:
+	 * Reloads the page with "showVersionDiffs" parameter inversed.
+	 *
+	 * @param req
+	 * 		StaplerRequest created by pressing the button
+	 * @param rsp
+	 * 		Outgoing StaplerResponse
+	 * @throws IOException
+	 * 		If XML file can't be read
+	 */
+	public final void doToggleShowHideVersionDiffs(StaplerRequest req,
+												   StaplerResponse rsp) throws IOException {
+		//simply reload current page.
+		final String timestamp1 = req.getParameter("timestamp1");
+		final String timestamp2 = req.getParameter("timestamp2");
+		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
+		rsp.sendRedirect("showDiffFiles?"
+				+ "timestamp1=" + timestamp1
+				+ "&timestamp2=" + timestamp2
+				+ "&showVersionDiffs=" + showVersionDiffs);
 	}
 
 	public Api getApi() {

--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
@@ -303,22 +303,11 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
 		return xmlFile.asString();
 	}
 
-	public final List<Line> getLines(boolean useRegex) throws IOException {
+	public final List<Line> getLines(boolean hideVersionDiffs) throws IOException {
 		checkConfigurePermission();
 		final String timestamp1 = getRequestParameter("timestamp1");
 		final String timestamp2 = getRequestParameter("timestamp2");
-
-		final XmlFile configXml1 = getOldConfigXml(timestamp1);
-		final String[] configXml1Lines = configXml1.asString().split("\\n");
-		final XmlFile configXml2 = getOldConfigXml(timestamp2);
-		final String[] configXml2Lines = configXml2.asString().split("\\n");
-
-		//compute the diff with respect to ignoredLinesPattern if useRegex == true
-		final String diffAsString = getDiffAsString(configXml1.getFile(),
-				configXml2.getFile(), configXml1Lines, configXml2Lines, useRegex);
-
-		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
-		return getDiffLines(diffLines);
+		return getLines(getOldConfigXml(timestamp1), getOldConfigXml(timestamp2), hideVersionDiffs);
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -65,9 +65,7 @@ import difflib.DiffUtils;
 import difflib.Patch;
 import difflib.StringUtills;
 
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
-import org.xmlunit.*;
 
 import hudson.XmlFile;
 import hudson.model.Action;
@@ -78,7 +76,6 @@ import jenkins.model.Jenkins;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.*;
-import org.xmlunit.util.Predicate;
 
 /**
  * Implements some basic methods needed by the
@@ -302,6 +299,36 @@ public abstract class JobConfigHistoryBaseAction implements Action {
         String showVersionDiffs = (String) (this.getRequestParameter("showVersionDiffs"));
         return (showVersionDiffs  == null) ? "True" : showVersionDiffs;
     }
+
+    /**
+     * Action when 'Show / hide Version Changes' button in the respective showDiffFiles.jelly is pressed:
+     * Reloads the page with "showVersionDiffs" parameter inversed.
+     *
+     * @param req
+     * 		StaplerRequest created by pressing the button
+     * @param rsp
+     * 		Outgoing StaplerResponse
+     * @throws IOException
+     * 		If XML file can't be read
+     */
+    public abstract void doToggleShowHideVersionDiffs(StaplerRequest req,
+                                                   StaplerResponse rsp) throws IOException;
+
+    /**
+     * Returns the diff between two config files as a list of single lines.
+     * Takes the two timestamps and the name of the system property or the
+     * deleted job from the url parameters.
+     *
+     * @return Differences between two config versions as list of lines.
+     * @throws IOException
+     *             If diff doesn't work or xml files can't be read.
+     */
+    public final List<Line> getLines() throws IOException {
+        final boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
+        return getLines(hideVersionDiffs);
+    }
+
+    public abstract List<Line> getLines(boolean useRegex) throws IOException;
 
     /**
      * Returns a unified diff between two string arrays representing an xml file.

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -298,9 +298,9 @@ public abstract class JobConfigHistoryBaseAction implements Action {
         }
         for (int i = 1; i < arr.length; ++i) {
             if (i < arr.length-1) {
-                ret += arr[i] + "\n";
+                ret = ret.concat(arr[i]).concat("\n");
             } else {
-                ret += arr[i];
+                ret = ret.concat(arr[i]);
             }
         }
         return ret;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -231,7 +231,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
 			for (Delta delta : patch.getDeltas()) {
 			    // Modify both deltas and save the changes.
-                System.out.println("-----delta" + delta);
 				List<String> originalLines = Lists.newArrayList((List<String>) delta.getOriginal().getLines());
 				List<String> revisedLines = Lists.newArrayList((List<String>) delta.getRevised().getLines());
 
@@ -263,7 +262,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 					    String originalLine = originalLines.get(line);
 					    String revisedLine = revisedLines.get(line);
                         String diff = StringUtils.difference(originalLine, revisedLine);
-                        System.out.println("--Diff: " + diff + " matches? " + diff.matches(ignoredDiffPattern));
 						// both lines are non-empty
 						if (originalLine.matches(ignoredLinesPattern)
 								&& revisedLine.matches(ignoredLinesPattern)

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.jobConfigHistory;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +32,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +50,6 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -214,7 +211,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
     }
 
     private Diff getVersionDiffsOnly(final File file1, final File file2) {
-        //TODO implement this, this is the way.
         DifferenceEvaluator versionDifferenceEvaluator = new DifferenceEvaluator() {
             //takes the comparison and the result that a possible previous DifferenceEvaluator created for this node
             // and compares the node based on whether there was a version change or not.
@@ -230,7 +226,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                 Node controlNode = comparison.getControlDetails().getTarget();
                 Node testNode = comparison.getTestDetails().getTarget();
                 if (controlNode == null || testNode == null) {
-                    //return comparisonResult;
                     return ComparisonResult.EQUAL;
                 }
 
@@ -306,16 +301,16 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 
         //calculate all diffs.
         final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
+
         if (hideVersionDiffs) {
             //calculate diffs to be excluded from the output.
             Diff versionDiffs = getVersionDiffsOnly(file1, file2);
-            //bug/ feature in library: empty deltas are shown, too.
+            //feature in library: empty deltas are shown, too.
             List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
             for (Delta delta : patch.getDeltas()) {
                 // Modify both deltas and save the changes.
                 List<String> originalLines = Lists.newArrayList((List<String>) delta.getOriginal().getLines());
                 List<String> revisedLines = Lists.newArrayList((List<String>) delta.getRevised().getLines());
-
                 for (Difference versionDifference : versionDiffs.getDifferences()) {
                     //check for each calculated versionDifference where it occured and delete it.
                     String controlValue = versionDifference.getComparison().getControlDetails().getValue().toString();
@@ -334,17 +329,9 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                                 //check only once for each occurence. Not necessarily needed, but makes it slightly faster.
                                 break;
                             }
-
                         }
                     }
-
                 }
-
-
-
-
-
-
                 if (originalLines.isEmpty() && revisedLines.isEmpty()) {
                     //remove the delta from the list.
                     deltasToBeRemovedAfterTheMainLoop.add(delta);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -411,7 +411,8 @@ public abstract class JobConfigHistoryBaseAction implements Action {
     }
 
 	private Writer sort(File file) throws IOException {
-		try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+		//FOR TEST PURPOSES...
+        /*try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
 			InputStream xslt = JobConfigHistoryBaseAction.class.getResourceAsStream("xslt/sort.xslt");
 			Objects.requireNonNull(xslt);
 			Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
@@ -425,7 +426,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			lr.setParameters(new Object[] { file.toPath() });
 			lr.setThrown(e);
 			LOG.log(lr);
-		}
+		}*/
 
 		// fallback - return an original file as is
 		Writer fallback = new StringWriter();
@@ -442,10 +443,24 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	protected final List<Line> getLines(XmlFile leftConfig, XmlFile rightConfig) throws IOException {
+	protected final List<Line> getLines(XmlFile leftConfig, XmlFile rightConfig, boolean hideVersionDiffs) throws IOException {
+
+	    //DEBUG: print before and after
+        System.out.println("-----------BEFORE SORTING:\n\n");
+        System.out.println(leftConfig.asString() + "\n\n");
+
 		final String[] leftLines = sort(leftConfig.getFile()).toString().split("\\n");
 		final String[] rightLines = sort(rightConfig.getFile()).toString().split("\\n");
-		final String diffAsString = getDiffAsString(leftConfig.getFile(), rightConfig.getFile(), leftLines, rightLines);
+
+        System.out.println("-----------AFTER SORTING:\n\n");
+        for (String line : leftLines) {
+            System.out.println(line);
+        }
+
+
+		final String diffAsString = getDiffAsString(leftConfig.getFile(), rightConfig.getFile(), leftLines,
+                rightLines, hideVersionDiffs);
+
 		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
 
 		return getDiffLines(diffLines);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -220,7 +220,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * @return unified diff
      */
 	protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
-			final String[] file2Lines, boolean useRegex, final String ignoredLinesPattern, final String ignoredDiffPattern) {
+			final String[] file2Lines, final boolean useRegex, final String ignoredLinesPattern, final String ignoredDiffPattern) {
 		final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
 		//TODO figure out something better than the bool-solution
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -411,7 +411,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
     }
 
 	private Writer sort(File file) throws IOException {
-		//FOR TEST PURPOSES...
+        //this produces a sorted xml without indentation. TODO find out how to get indentation.
         /*try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
 			InputStream xslt = JobConfigHistoryBaseAction.class.getResourceAsStream("xslt/sort.xslt");
 			Objects.requireNonNull(xslt);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -412,7 +412,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 
 	private Writer sort(File file) throws IOException {
         //this produces a sorted xml without indentation. TODO find out how to get indentation.
-        /*try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+        try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
 			InputStream xslt = JobConfigHistoryBaseAction.class.getResourceAsStream("xslt/sort.xslt");
 			Objects.requireNonNull(xslt);
 			Transformer transformer = transformerFactory.newTransformer(new StreamSource(xslt));
@@ -426,7 +426,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			lr.setParameters(new Object[] { file.toPath() });
 			lr.setThrown(e);
 			LOG.log(lr);
-		}*/
+		}
 
 		// fallback - return an original file as is
 		Writer fallback = new StringWriter();
@@ -446,16 +446,16 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 	protected final List<Line> getLines(XmlFile leftConfig, XmlFile rightConfig, boolean hideVersionDiffs) throws IOException {
 
 	    //DEBUG: print before and after
-        System.out.println("-----------BEFORE SORTING:\n\n");
-        System.out.println(leftConfig.asString() + "\n\n");
+        /*System.out.println("-----------BEFORE SORTING:\n\n");
+        System.out.println(leftConfig.asString() + "\n\n");*/
 
 		final String[] leftLines = sort(leftConfig.getFile()).toString().split("\\n");
 		final String[] rightLines = sort(rightConfig.getFile()).toString().split("\\n");
 
-        System.out.println("-----------AFTER SORTING:\n\n");
+        /*System.out.println("-----------AFTER SORTING:\n\n");
         for (String line : leftLines) {
             System.out.println(line);
-        }
+        }*/
 
 
 		final String diffAsString = getDiffAsString(leftConfig.getFile(), rightConfig.getFile(), leftLines,

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -317,7 +317,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                     String testValue     = versionDifference.getComparison().getTestDetails().getValue().toString();
                     for (int line = 0; line < Math.max(originalLines.size(), revisedLines.size()); ++line) {
                         //go through each line and search for the diff
-                        if ((line > originalLines.size()-1) || (line > revisedLines.size())) {
+                        if ((line > originalLines.size()-1) || (line > revisedLines.size()-1)) {
                             //too lazy to reformat this to the right negated expression...
                         } else {
                             String originalLine = originalLines.get(line);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -274,20 +274,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
     }
 
     /**
-     * Action when 'Show / hide Version Changes' button in the respective showDiffFiles.jelly is pressed:
-     * Reloads the page with "showVersionDiffs" parameter inversed.
-     *
-     * @param req
-     * 		StaplerRequest created by pressing the button
-     * @param rsp
-     * 		Outgoing StaplerResponse
-     * @throws IOException
-     * 		If XML file can't be read
-     */
-    public abstract void doToggleShowHideVersionDiffs(StaplerRequest req,
-                                                   StaplerResponse rsp) throws IOException;
-
-    /**
      * Returns the diff between two config files as a list of single lines.
      * Takes the two timestamps and the name of the system property or the
      * deleted job from the url parameters.
@@ -311,16 +297,16 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * @param file2               second config file.
      * @param file1Lines          the lines of the first file.
      * @param file2Lines          the lines of the second file.
-     * @param useRegex            determines whether <b>ignoredLinesPattern</b> shall be used.
+     * @param hideVersionDiffs            determines whether version diffs shall be shown or not.
      * @return unified diff
      */
     protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
-                                           final String[] file2Lines, final boolean useRegex) {
+                                           final String[] file2Lines, final boolean hideVersionDiffs) {
 
 
         //calculate all diffs.
         final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
-        if (useRegex) {
+        if (hideVersionDiffs) {
             //calculate diffs to be excluded from the output.
             Diff versionDiffs = getVersionDiffsOnly(file1, file2);
             //bug/ feature in library: empty deltas are shown, too.

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -225,42 +225,42 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			for (Delta delta : patch.getDeltas()) {
 				List<String> originalLines = Lists.newArrayList((List<String>) delta.getOriginal().getLines());
 				List<String> revisedLines = Lists.newArrayList((List<String>) delta.getRevised().getLines());
-				//---------------------------------------------------------------------------------------------------------------DEBUG
-				System.out.println("---BEFORE:");
-				System.out.println("Original Lines: " + originalLines);
-				System.out.println("Revised Lines: " +revisedLines);
-				//--------------------------------------------------------------------------------------------------------------\DEBUG
+				//------------------------------------------------------------------------------------------------------DEBUG
+				//System.out.println("---BEFORE:");
+				//System.out.println("Original Lines: " + originalLines);
+				//System.out.println("Revised Lines: " +revisedLines);
+				//------------------------------------------------------------------------------------------------------\DEBUG
 				for (int line = 0; line < Math.max(originalLines.size(), revisedLines.size()); ++line) {
-					// TODO: this is crappy, O(n) if not ArrayList, change that.
+					// One iteration is O(n), if originalLines or revisedLines aren't ArrayLists!
 					int oriLinesSize = originalLines.size();
 					int revLinesSize = revisedLines.size();
-					//---------------------------------------------------------------------------------------------------------------DEBUG
-					System.out.println("---MID:");
-					//--------------------------------------------------------------------------------------------------------------\DEBUG
+					//--------------------------------------------------------------------------------------------------DEBUG
+					//System.out.println("---MID:");
+					//--------------------------------------------------------------------------------------------------\DEBUG
 					if (line > oriLinesSize - 1) {
 						// line <= revLinesSize-1, because of loop invariant.
 						// ori line is empty.
-						//---------------------------------------------------------------------------------------------------------------DEBUG
-						System.out.println("Line Pair: [" + "EMPTYY" + ", " + revisedLines.get(line) + "]");
-						//--------------------------------------------------------------------------------------------------------------\DEBUG
+						//----------------------------------------------------------------------------------------------DEBUG
+						//System.out.println("Line Pair: [" + "EMPTYY" + ", " + revisedLines.get(line) + "]");
+						//----------------------------------------------------------------------------------------------\DEBUG
 						if (revisedLines.get(line).matches(ignoredLinesPattern)) {
 							revisedLines.remove(line);
 						}
 					} else if (line > revLinesSize - 1) {
 						// line <= oriLinesSize-1, because of loop invariant.
 						// rev line is empty.
-						//---------------------------------------------------------------------------------------------------------------DEBUG
-						System.out.println("Line Pair: [" + originalLines.get(line) + ", " + "EMPTYY" + "]");
-						//--------------------------------------------------------------------------------------------------------------\DEBUG
+						//----------------------------------------------------------------------------------------------DEBUG
+						//System.out.println("Line Pair: [" + originalLines.get(line) + ", " + "EMPTYY" + "]");
+						//----------------------------------------------------------------------------------------------\DEBUG
 						if (originalLines.get(line).matches(ignoredLinesPattern)) {
 							originalLines.remove(line);
 						}
 					} else {
 						// both lines are non-empty
-						//---------------------------------------------------------------------------------------------------------------DEBUG
-						System.out.println(
-								"Line Pair: [" + originalLines.get(line) + ", " + revisedLines.get(line) + "]");
-						//--------------------------------------------------------------------------------------------------------------\DEBUG
+						//----------------------------------------------------------------------------------------------DEBUG
+						//System.out.println(
+						//		"Line Pair: [" + originalLines.get(line) + ", " + revisedLines.get(line) + "]");
+						//----------------------------------------------------------------------------------------------\DEBUG
 						if ((originalLines.get(line).matches(ignoredLinesPattern))
 								&& (revisedLines.get(line).matches(ignoredLinesPattern))) {
 							originalLines.remove(line);
@@ -273,9 +273,9 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 					deltasToBeRemovedAfterTheMainLoop.add(delta);
 				}
 				//---------------------------------------------------------------------------------------------------------------DEBUG
-				System.out.println("---AFTER:");
-				System.out.println("Original Lines: " + originalLines);
-				System.out.println("Revised Lines: " +revisedLines);
+				//System.out.println("---AFTER:");
+				//System.out.println("Original Lines: " + originalLines);
+				//System.out.println("Revised Lines: " +revisedLines);
 				//--------------------------------------------------------------------------------------------------------------\DEBUG
 				delta.getOriginal().setLines(originalLines);
 				delta.getRevised().setLines(revisedLines);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -201,15 +201,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 	 */
 	protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
 			final String[] file2Lines) {
-		/*
-		 * final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines),
-		 * Arrays.asList(file2Lines)); final List<String> unifiedDiff =
-		 * DiffUtils.generateUnifiedDiff( file1.getPath(), file2.getPath(),
-		 * Arrays.asList(file1Lines), patch, 3); return StringUtills.join(unifiedDiff,
-		 * "\n") + "\n";
-		 */
-		// return getDiffAsString(file1, file2,
-		// file1Lines, file2Lines, "");
 		return getDiffAsString(file1, file2, file1Lines, file2Lines, false, "");
 	}
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -214,7 +214,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * @param file2Lines the lines of the second file.
      * @param useRegex determines whether <b>ignoredLinesPattern</b> shall be used.
      * @param ignoredLinesPattern line pairs in which both lines
-     *                           match this pattern are deleted.
+     *                            match this pattern are deleted.
      * @param ignoredDiffPattern the diff between two lines must
      *                           match this pattern for the line to be deleted.
      * @return unified diff
@@ -223,11 +223,9 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			final String[] file2Lines, boolean useRegex, final String ignoredLinesPattern, final String ignoredDiffPattern) {
 		final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
 		//TODO figure out something better than the bool-solution
-        //TODO problem: if hide version changes results in "no diffs found", an older change is loaded automatically. That is unwanted behaviour.
 
 		if (useRegex) {
 			//bug/ feature in library: empty deltas are shown, too.
-			//TODO probably need to adjust the non-empty deltas also...
 			List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
 			for (Delta delta : patch.getDeltas()) {
 			    // Modify both deltas and save the changes.

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.jobConfigHistory;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +33,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -62,12 +64,21 @@ import difflib.Delta;
 import difflib.DiffUtils;
 import difflib.Patch;
 import difflib.StringUtills;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.xmlunit.*;
+
 import hudson.XmlFile;
 import hudson.model.Action;
 import hudson.plugins.jobConfigHistory.SideBySideView.Line;
 import hudson.security.AccessControlled;
 import hudson.util.MultipartFormDataParser;
 import jenkins.model.Jenkins;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.*;
+import org.xmlunit.util.Predicate;
 
 /**
  * Implements some basic methods needed by the
@@ -77,10 +88,10 @@ import jenkins.model.Jenkins;
  */
 public abstract class JobConfigHistoryBaseAction implements Action {
 
-	/**
-	 * The jenkins instance.
-	 */
-	private final Jenkins jenkins;
+    /**
+     * The jenkins instance.
+     */
+    private final Jenkins jenkins;
 
 	private final TransformerFactory transformerFactory = TransformerFactory.newInstance();
 
@@ -93,117 +104,103 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 		jenkins = Jenkins.getInstance();
 	}
 
-	/**
-	 * For tests only.
-	 *
-	 * @param jenkins injected jenkins
-	 */
-	JobConfigHistoryBaseAction(Jenkins jenkins) {
-		this.jenkins = jenkins;
-	}
+    /**
+     * For tests only.
+     *
+     * @param jenkins injected jenkins
+     */
+    JobConfigHistoryBaseAction(Jenkins jenkins) {
+        this.jenkins = jenkins;
+    }
 
-	@Override
-	public String getDisplayName() {
-		return Messages.displayName();
-	}
+    @Override
+    public String getDisplayName() {
+        return Messages.displayName();
+    }
 
-	@Override
-	public String getUrlName() {
-		return JobConfigHistoryConsts.URLNAME;
-	}
+    @Override
+    public String getUrlName() {
+        return JobConfigHistoryConsts.URLNAME;
+    }
 
-	/**
-	 * Returns how the config file should be formatted in configOutput.jelly: as
-	 * plain text or xml.
-	 *
-	 * @return "plain" or "xml"
-	 */
-	public final String getOutputType() {
-		if (("xml").equalsIgnoreCase(getRequestParameter("type"))) {
-			return "xml";
-		}
-		return "plain";
-	}
+    /**
+     * Returns how the config file should be formatted in configOutput.jelly: as
+     * plain text or xml.
+     *
+     * @return "plain" or "xml"
+     */
+    public final String getOutputType() {
+        if (("xml").equalsIgnoreCase(getRequestParameter("type"))) {
+            return "xml";
+        }
+        return "plain";
+    }
 
-	/**
-	 * Checks the url parameter 'timestamp' and returns true if it is parseable as a
-	 * date.
-	 * 
-	 * @param timestamp Timestamp of config change.
-	 * @return True if timestamp is okay.
-	 */
-	protected boolean checkTimestamp(String timestamp) {
-		if (timestamp == null || "null".equals(timestamp)) {
-			return false;
-		}
-		PluginUtils.parsedDate(timestamp);
-		return true;
-	}
+    /**
+     * Checks the url parameter 'timestamp' and returns true if it is parseable as a
+     * date.
+     *
+     * @param timestamp Timestamp of config change.
+     * @return True if timestamp is okay.
+     */
+    protected boolean checkTimestamp(String timestamp) {
+        if (timestamp == null || "null".equals(timestamp)) {
+            return false;
+        }
+        PluginUtils.parsedDate(timestamp);
+        return true;
+    }
 
-	/**
-	 * Returns the parameter named {@code parameterName} from current request.
-	 *
-	 * @param parameterName name of the parameter.
-	 * @return value of the request parameter or null if it does not exist.
-	 */
-	protected String getRequestParameter(final String parameterName) {
-		return getCurrentRequest().getParameter(parameterName);
-	}
+    /**
+     * Returns the parameter named {@code parameterName} from current request.
+     *
+     * @param parameterName name of the parameter.
+     * @return value of the request parameter or null if it does not exist.
+     */
+    protected String getRequestParameter(final String parameterName) {
+        return getCurrentRequest().getParameter(parameterName);
+    }
 
-	/**
-	 * See whether the current user may read configurations in the object returned
-	 * by {@link JobConfigHistoryBaseAction#getAccessControlledObject()}.
-	 */
-	protected abstract void checkConfigurePermission();
+    /**
+     * See whether the current user may read configurations in the object returned
+     * by {@link JobConfigHistoryBaseAction#getAccessControlledObject()}.
+     */
+    protected abstract void checkConfigurePermission();
 
-	/**
-	 * Returns whether the current user may read configurations in the object
-	 * returned by {@link JobConfigHistoryBaseAction#getAccessControlledObject()}.
-	 *
-	 * @return true if the current user may read configurations.
-	 */
-	protected abstract boolean hasConfigurePermission();
+    /**
+     * Returns whether the current user may read configurations in the object
+     * returned by {@link JobConfigHistoryBaseAction#getAccessControlledObject()}.
+     *
+     * @return true if the current user may read configurations.
+     */
+    protected abstract boolean hasConfigurePermission();
 
-	/**
-	 * Returns the jenkins instance.
-	 *
-	 * @return the jenkins
-	 */
-	protected Jenkins getJenkins() {
-		return jenkins;
-	}
+    /**
+     * Returns the jenkins instance.
+     *
+     * @return the jenkins
+     */
+    protected Jenkins getJenkins() {
+        return jenkins;
+    }
 
-	/**
-	 * Returns the object for which we want to provide access control.
-	 *
-	 * @return the access controlled object.
-	 */
-	protected abstract AccessControlled getAccessControlledObject();
+    /**
+     * Returns the object for which we want to provide access control.
+     *
+     * @return the access controlled object.
+     */
+    protected abstract AccessControlled getAccessControlledObject();
 
-	/**
-	 * Returns side-by-side (i.e. human-readable) diff view lines.
-	 *
-	 * @param diffLines Unified diff as list of Strings.
-	 * @return Nice and clean diff as list of single Lines. if reading one of the
-	 *         config files does not succeed.
-	 */
-	public final List<Line> getDiffLines(List<String> diffLines) throws IOException {
-		return new GetDiffLines(diffLines).get();
-	}
-
-	/**
-	 * Returns a unified diff between two string arrays.
-	 *
-	 * @param file1      first config file.
-	 * @param file2      second config file.
-	 * @param file1Lines the lines of the first file.
-	 * @param file2Lines the lines of the second file.
-	 * @return unified diff
-	 */
-	protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
-			final String[] file2Lines) {
-		return getDiffAsString(file1, file2, file1Lines, file2Lines, false, "", "");
-	}
+    /**
+     * Returns side-by-side (i.e. human-readable) diff view lines.
+     *
+     * @param diffLines Unified diff as list of Strings.
+     * @return Nice and clean diff as list of single Lines. if reading one of the
+     * config files does not succeed.
+     */
+    public final List<Line> getDiffLines(List<String> diffLines) throws IOException {
+        return new GetDiffLines(diffLines).get();
+    }
 
     /**
      * Returns a unified diff between two string arrays.
@@ -212,140 +209,317 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * @param file2      second config file.
      * @param file1Lines the lines of the first file.
      * @param file2Lines the lines of the second file.
-     * @param useRegex determines whether <b>ignoredLinesPattern</b> shall be used.
-     * @param ignoredLinesPattern line pairs in which both lines
-     *                            match this pattern are deleted.
-     * @param ignoredDiffPattern the diff between two lines must
-     *                           match this pattern for the line to be deleted.
      * @return unified diff
      */
-	protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
-			final String[] file2Lines, final boolean useRegex, final String ignoredLinesPattern, final String ignoredDiffPattern) {
-		final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
-		//TODO figure out something better than the bool-solution
+    protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
+                                           final String[] file2Lines) {
+        return getDiffAsString(file1, file2, file1Lines, file2Lines, false, "", "");
+    }
 
-		if (useRegex) {
-			//bug/ feature in library: empty deltas are shown, too.
-			List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
-			for (Delta delta : patch.getDeltas()) {
-			    // Modify both deltas and save the changes.
-				List<String> originalLines = Lists.newArrayList((List<String>) delta.getOriginal().getLines());
-				List<String> revisedLines = Lists.newArrayList((List<String>) delta.getRevised().getLines());
+    /**
+     * Returns a unified diff between two string arrays.
+     *
+     * @param file1               first config file.
+     * @param file2               second config file.
+     * @param file1Lines          the lines of the first file.
+     * @param file2Lines          the lines of the second file.
+     * @param useRegex            determines whether <b>ignoredLinesPattern</b> shall be used.
+     * @param ignoredLinesPattern line pairs in which both lines
+     *                            match this pattern are deleted.
+     * @param ignoredDiffPattern  the diff between two lines must
+     *                            match this pattern for the line to be deleted.
+     * @return unified diff
+     */
+    protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
+                                           final String[] file2Lines, final boolean useRegex, final String ignoredLinesPattern, final String ignoredDiffPattern) {
 
-				for (int line = 0; line < Math.max(originalLines.size(), revisedLines.size()); ++line) {
-				    // Delete lines which match the regex from both deltas.
+        //TODO implement this, this is the way.
+        DifferenceEvaluator versionDifferenceEvaluator = new DifferenceEvaluator() {
+            //takes the comparison and the result that a possible previous DifferenceEvaluator created for this node
+            // and compares the node based on whether there was a version change or not.
+            // if there wasn't, "comparisonResult" is returned.
+            //TODO find the name of this software pattern
+            @Override
+            public ComparisonResult evaluate(Comparison comparison, ComparisonResult comparisonResult) {
+
+                //System.out.println("++++++++++++Test4++++++++++++: " + comparisonResult + " compType: " + comparison.getType());
+                try {
+
+                    if (comparison.getControlDetails().getValue().toString().contains("git@")) {
+                        System.out.println("comparison with periodic stuff: " + comparison.getControlDetails().getValue().toString()
+                                + "Type: " + comparison.getType());
+                    }
+                } catch (NullPointerException e) {;}
+                if (comparison.getType() != ComparisonType.ATTR_VALUE) {
+                    //only want to compare attribute values!
+
+
+                    //TODO wieder zurückändern!
+                    //return comparisonResult;
+                    return ComparisonResult.EQUAL;
+                }
+
+                Node controlNode = comparison.getControlDetails().getTarget();
+                Node testNode = comparison.getTestDetails().getTarget();
+                if (controlNode == null || testNode == null) {
+
+                    //TODO wieder zurückändern
+                    //return comparisonResult;
+                    return ComparisonResult.EQUAL;
+                }
+                System.out.println("Value:" + comparison.getControlDetails().getValue());
+                System.out.println("  Control Node: " + controlNode.getNodeName() + ", Test Node: " + testNode.getNodeName());
+
+                String[] controlValue = controlNode.getNodeValue().split("@");
+                String[] testValue = testNode.getNodeValue().split("@");
+
+
+                if (!controlValue[0].equals(testValue[0])
+                        || controlValue.length != 2 || testValue.length != 2) {
+                    //different plugins or misformatted plugin attribute: version number not determinable
+                    //TODO wieder zurückändern
+                    //return comparisonResult;
+                    return ComparisonResult.EQUAL;
+                }
+                System.out.println("  found as equal: " + controlValue[1] + ", " + testValue[1]);
+                //TODO wieder zurückändern
+                //return ComparisonResult.EQUAL;
+                if (controlValue[1].equals(testValue[1])) {
+                    return ComparisonResult.EQUAL;
+                } else {
+                    return ComparisonResult.DIFFERENT;
+                }
+
+
+                    /*
+                    NamedNodeMap testNodeMap;
+                    NamedNodeMap controlNodeMap;
+                    if (controlNode.hasAttributes() && testNode.hasAttributes()) {
+                        controlNodeMap = controlNode.getAttributes();
+                        testNodeMap = testNode.getAttributes();
+
+                        if (controlNodeMap.getLength() == 0 && testNodeMap.getLength() == 0) {
+                            //nothing more to do here, only need nodes where there are attributes (possibly containing version values)
+                            return comparisonResult;
+                        }
+                    } else {
+                        //nothing more to do here, only need nodes where there are attributes (possibly containing version values)
+                        return comparisonResult;
+                    }
+                    System.out.println("HAAAAAAAAAAAAAAAAAALLO3");
+                    //todo damit lässt sich potenziell die top-position finden.
+                    controlNode.getParentNode();
+
+                    //System.out.println("plugin-item: " + controlNode.getAttributes().getNamedItem("plugin"));
+                    Node controlNodePluginAttribute =           controlNode.getAttributes().getNamedItem("plugin");
+                    Node testNodePluginAttribute =              testNode.getAttributes().getNamedItem("plugin");
+                    if (controlNodePluginAttribute == null || testNodePluginAttribute == null) {
+                        return comparisonResult;
+                    }
+                    //they look like this: testPlugin@1.2.3
+                    String controlNodePluginAttributeValue =    controlNodePluginAttribute.getNodeValue();
+                    String testNodePluginAttributeValue =       testNodePluginAttribute.getNodeValue();
+
+                    System.out.println("lalal: " + controlNodePluginAttributeValue + ", " + testNodePluginAttributeValue);
+                    String[] controlNodePluginNameAndVersion =  controlNodePluginAttributeValue.split("@");
+                    String[] testNodePluginNameAndVersion =     testNodePluginAttributeValue.split("@");
+                    if (!controlNodePluginNameAndVersion[0].equals(testNodePluginNameAndVersion[0])
+                            || controlNodePluginNameAndVersion.length != 2 || testNodePluginNameAndVersion.length != 2) {
+                        //different plugins or misformatted plugin attribute: version number not determinable
+                        return comparisonResult;
+                    }
+                    //if  the version differs or not, return equal.
+                    System.out.println("equal plugin names: " + controlNodePluginAttribute + ", " + testNodePluginAttribute);
+                    return ComparisonResult.EQUAL;
+
+
+                    */
+            }
+        };
+
+        Diff diff = DiffBuilder.compare(Input.fromFile(file1)).withTest(Input.fromFile(file2))
+                .ignoreWhitespace()
+                //.withNodeFilter(nodeFilter)		//DONT USE THIS, but the next one!!
+                //.withDifferenceEvaluator(DifferenceEvaluators.chain(DifferenceEvaluators.Default, versionDifferenceEvaluator))    //not so sure bout this one.
+                //.withDifferenceEvaluator(DifferenceEvaluators.Default)
+                .withDifferenceEvaluator(versionDifferenceEvaluator)
+                .build();
+        System.out.println("\n\n\n\n DIFFERENCES! \n\n\n\n");
+        int diffCount = 0;
+
+        HashMap<String, String> diffsAsMap = new HashMap<String, String>();
+        for (Difference difference : diff.getDifferences()) {
+            System.out.println("Comparison type: " + difference.getComparison().getType());
+            System.out.println("    diff ctrl value: " + difference.getComparison().getControlDetails().getValue());
+            System.out.println("    diff test value: " + difference.getComparison().getTestDetails().getValue());
+            System.out.println("    diff ctrl xpath: " + difference.getComparison().getControlDetails().getXPath());
+
+            diffsAsMap.put(
+                    difference.getComparison().getControlDetails().getValue().toString(),
+                    difference.getComparison().getTestDetails().getValue().toString()
+            );
+            diffCount++;
+        }
+        System.out.println("  +++DiffCount+++: " + diffCount);
+
+
+        //current test: XMLUnit XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+        final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
+
+        //TODO figure out something better than the bool-solution
+
+        if (useRegex) {
+            //bug/ feature in library: empty deltas are shown, too.
+            List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
+            for (Delta delta : patch.getDeltas()) {
+                // Modify both deltas and save the changes.
+                List<String> originalLines = Lists.newArrayList((List<String>) delta.getOriginal().getLines());
+                List<String> revisedLines = Lists.newArrayList((List<String>) delta.getRevised().getLines());
+
+                for (int line = 0; line < Math.max(originalLines.size(), revisedLines.size()); ++line) {
+                    // Delete lines which match the regex from both deltas.
 
                     //These must be calculated IN the loop because it changes in some iterations.
                     int oriLinesSize = originalLines.size();
                     int revLinesSize = revisedLines.size();
 
 
-					if (line > oriLinesSize - 1) {
-						// line <= revLinesSize-1, because of loop invariant.
-						// ori line is empty.
-						if (revisedLines.get(line).matches(ignoredLinesPattern)) {
+                    if (line > oriLinesSize - 1) {
+                        // line <= revLinesSize-1, because of loop invariant.
+                        // ori line is empty.
+                        if (revisedLines.get(line).matches(ignoredLinesPattern)) {
                             //TODO this should be decided by method call, if the functionality is needed
-							//this line is needed if a deleted or added line that matches the pattern should be hidden.
-							//revisedLines.remove(line);
-						}
-					} else if (line > revLinesSize - 1) {
-						// line <= oriLinesSize-1, because of loop invariant.
-						// rev line is empty.
-						if (originalLines.get(line).matches(ignoredLinesPattern)) {
-							//this line is needed if a deleted or added line that matches the pattern should be hidden.
+                            //this line is needed if a deleted or added line that matches the pattern should be hidden.
+                            //revisedLines.remove(line);
+                        }
+                    } else if (line > revLinesSize - 1) {
+                        // line <= oriLinesSize-1, because of loop invariant.
+                        // rev line is empty.
+                        if (originalLines.get(line).matches(ignoredLinesPattern)) {
+                            //this line is needed if a deleted or added line that matches the pattern should be hidden.
                             //TODO this should be decided by method call, if the functionality is needed
-							//originalLines.remove(line);
-						}
-					} else {
-					    String originalLine = originalLines.get(line);
-					    String revisedLine = revisedLines.get(line);
-                        String diff = StringUtils.difference(originalLine, revisedLine);
-						// both lines are non-empty
-						if (originalLine.matches(ignoredLinesPattern)
-								&& revisedLine.matches(ignoredLinesPattern)
-                                && diff.matches(ignoredDiffPattern)) {
-							originalLines.remove(line);
-							revisedLines.remove(line);
+                            //originalLines.remove(line);
+                        }
+                    } else {
+                        String originalLine = originalLines.get(line);
+                        String revisedLine = revisedLines.get(line);
+                        String diffStr = StringUtils.difference(originalLine, revisedLine);
+                        // both lines are non-empty
+                        //TODO reset this if needed!!!
+                        /*
+                        if (originalLine.matches(ignoredLinesPattern)
+                                && revisedLine.matches(ignoredLinesPattern)
+                                && diffStr.matches(ignoredDiffPattern)) {
+                            originalLines.remove(line);
+                            revisedLines.remove(line);
 
-						}
-					}
-				}
-				if (originalLines.isEmpty() && revisedLines.isEmpty()) {
-					//remove the delta from the list.
-					deltasToBeRemovedAfterTheMainLoop.add(delta);
-				}
-				delta.getOriginal().setLines(originalLines);
-				delta.getRevised().setLines(revisedLines);
-			}
-			patch.getDeltas().removeAll(deltasToBeRemovedAfterTheMainLoop);
-		}
+                        }
+                        */
+                        for (Difference difference : diff.getDifferences()) {
+                            String controlValue = difference.getComparison().getControlDetails().getValue().toString();
+                            String testValue     = difference.getComparison().getTestDetails().getValue().toString();
 
-		final List<String> unifiedDiff = DiffUtils.generateUnifiedDiff(file1.getPath(), file2.getPath(),
-				Arrays.asList(file1Lines), patch, 3);
-		return StringUtills.join(unifiedDiff, "\n") + "\n";
-	}
+                            if ((originalLine.contains(controlValue) && revisedLine.contains(testValue))
+                            || (originalLine.contains(testValue) && revisedLine.contains(controlValue))) {
+                                originalLines.remove(line);
+                                revisedLines.remove(line);
+                            }
+                        }
+                    }
+                }
+                if (originalLines.isEmpty() && revisedLines.isEmpty()) {
+                    //remove the delta from the list.
+                    deltasToBeRemovedAfterTheMainLoop.add(delta);
+                }
+                delta.getOriginal().setLines(originalLines);
+                delta.getRevised().setLines(revisedLines);
+            }
+            patch.getDeltas().removeAll(deltasToBeRemovedAfterTheMainLoop);
+        }
 
-	/**
-	 * Parses the incoming {@literal POST} request and redirects as
-	 * {@literal GET showDiffFiles}.
-	 *
-	 * @param req incoming request
-	 * @param rsp outgoing response
-	 * @throws ServletException when parsing the request as
-	 *                          {@link MultipartFormDataParser} does not succeed.
-	 * @throws IOException      when the redirection does not succeed.
-	 */
-	public void doDiffFiles(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-		String timestamp1 = req.getParameter("timestamp1");
-		String timestamp2 = req.getParameter("timestamp2");
+        final List<String> unifiedDiff = DiffUtils.generateUnifiedDiff(file1.getPath(), file2.getPath(),
+                Arrays.asList(file1Lines), patch, 3);
 
-		if (PluginUtils.parsedDate(timestamp1).after(PluginUtils.parsedDate(timestamp2))) {
-			timestamp1 = req.getParameter("timestamp2");
-			timestamp2 = req.getParameter("timestamp1");
-		}
-		rsp.sendRedirect("showDiffFiles?timestamp1=" + timestamp1 + "&timestamp2=" + timestamp2);
-	}
+        System.out.println("\n\n\n DIFFUTILS unifiedDiff:");
+        for (String s : unifiedDiff) {
+            System.out.println("diffLine = " + s);
+        }
+        return StringUtills.join(unifiedDiff, "\n") + "\n";
+    }
 
-	/**
-	 * Action when 'Prev' or 'Next' button in showDiffFiles.jelly is pressed.
-	 * Forwards to the previous or next diff.
-	 * 
-	 * @param req StaplerRequest created by pressing the button
-	 * @param rsp Outgoing StaplerResponse
-	 * @throws IOException If XML file can't be read
-	 */
-	public final void doDiffFilesPrevNext(StaplerRequest req, StaplerResponse rsp) throws IOException {
-		final String timestamp1 = req.getParameter("timestamp1");
-		final String timestamp2 = req.getParameter("timestamp2");
-		rsp.sendRedirect("showDiffFiles?timestamp1=" + timestamp1 + "&timestamp2=" + timestamp2);
-	}
+    private static String stringArrayToString(String[] arr) {
+        String result = "";
+        for (int i = 0; i < arr.length; ++i) {
+            result += arr[i];
+            if (i < arr.length - 1) {
+                result += "\n";
+            }
+        }
+        return result;
+    }
 
-	/**
-	 * Overridable for tests.
-	 *
-	 * @return current request
-	 */
-	protected StaplerRequest getCurrentRequest() {
-		return Stapler.getCurrentRequest();
-	}
+    /**
+     * Parses the incoming {@literal POST} request and redirects as
+     * {@literal GET showDiffFiles}.
+     *
+     * @param req incoming request
+     * @param rsp outgoing response
+     * @throws ServletException when parsing the request as
+     *                          {@link MultipartFormDataParser} does not succeed.
+     * @throws IOException      when the redirection does not succeed.
+     */
+    public void doDiffFiles(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
+        String timestamp1 = req.getParameter("timestamp1");
+        String timestamp2 = req.getParameter("timestamp2");
 
-	/**
-	 * Returns the plugin for tests.
-	 *
-	 * @return plugin
-	 */
-	protected JobConfigHistory getPlugin() {
-		return PluginUtils.getPlugin();
-	}
+        if (PluginUtils.parsedDate(timestamp1).after(PluginUtils.parsedDate(timestamp2))) {
+            timestamp1 = req.getParameter("timestamp2");
+            timestamp2 = req.getParameter("timestamp1");
+        }
+        rsp.sendRedirect("showDiffFiles?timestamp1=" + timestamp1 + "&timestamp2=" + timestamp2);
+    }
 
-	/**
-	 * For tests.
-	 *
-	 * @return historyDao
-	 */
-	protected HistoryDao getHistoryDao() {
-		return PluginUtils.getHistoryDao();
-	}
+    /**
+     * Action when 'Prev' or 'Next' button in showDiffFiles.jelly is pressed.
+     * Forwards to the previous or next diff.
+     *
+     * @param req StaplerRequest created by pressing the button
+     * @param rsp Outgoing StaplerResponse
+     * @throws IOException If XML file can't be read
+     */
+    public final void doDiffFilesPrevNext(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        final String timestamp1 = req.getParameter("timestamp1");
+        final String timestamp2 = req.getParameter("timestamp2");
+        rsp.sendRedirect("showDiffFiles?timestamp1=" + timestamp1 + "&timestamp2=" + timestamp2);
+    }
+
+    /**
+     * Overridable for tests.
+     *
+     * @return current request
+     */
+    protected StaplerRequest getCurrentRequest() {
+        return Stapler.getCurrentRequest();
+    }
+
+    /**
+     * Returns the plugin for tests.
+     *
+     * @return plugin
+     */
+    protected JobConfigHistory getPlugin() {
+        return PluginUtils.getPlugin();
+    }
+
+    /**
+     * For tests.
+     *
+     * @return historyDao
+     */
+    protected HistoryDao getHistoryDao() {
+        return PluginUtils.getHistoryDao();
+    }
 
 	private Writer sort(File file) throws IOException {
 		try (Reader source = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -222,51 +222,25 @@ public abstract class JobConfigHistoryBaseAction implements Action {
             //TODO find the name of this software pattern
             @Override
             public ComparisonResult evaluate(Comparison comparison, ComparisonResult comparisonResult) {
-
-                //System.out.println("++++++++++++Test4++++++++++++: " + comparisonResult + " compType: " + comparison.getType());
-                try {
-
-                    if (comparison.getControlDetails().getValue().toString().contains("lalala@")) {
-                        System.out.println("comparison with periodic stuff: " + comparison.getControlDetails().getValue().toString()
-                                + "Type: " + comparison.getType());
-                    }
-                } catch (NullPointerException e) {;}
                 if (comparison.getType() != ComparisonType.ATTR_VALUE) {
                     //only want to compare attribute values!
-
-
-                    //TODO wieder zurückändern, falls XML-Unit für alle diffs genutzt werden soll.
-                    //return comparisonResult;
                     return ComparisonResult.EQUAL;
                 }
 
                 Node controlNode = comparison.getControlDetails().getTarget();
                 Node testNode = comparison.getTestDetails().getTarget();
                 if (controlNode == null || testNode == null) {
-
-                    //TODO wieder zurückändern, falls XML-Unit für alle diffs genutzt werden soll.
                     //return comparisonResult;
                     return ComparisonResult.EQUAL;
                 }
-                System.out.println(
-                        "  Control Node: " + controlNode.getNodeName() + ", " + controlNode.getNodeValue()
-                                + ", Test Node: " + testNode.getNodeName() + ", " + testNode.getNodeValue());
 
                 String[] controlValue = controlNode.getNodeValue().split("@");
                 String[] testValue = testNode.getNodeValue().split("@");
-
-
                 if (!controlValue[0].equals(testValue[0])
                         || controlValue.length != 2 || testValue.length != 2) {
                     //different plugins or misformatted plugin attribute: version number not determinable
-                    //TODO wieder zurückändern, falls XML-Unit für alle diffs genutzt werden soll.
-                    //return comparisonResult;
-                    System.out.println("misformatted plugin attribute or different plugins");
                     return ComparisonResult.EQUAL;
                 }
-                System.out.println("  found as equal: " + controlValue[1] + ", " + testValue[1]);
-                //TODO wieder zurückändern, falls XML-Unit für alle diffs genutzt werden soll.
-                //return ComparisonResult.EQUAL;
                 if (controlValue[1].equals(testValue[1])) {
                     return ComparisonResult.EQUAL;
                 } else {
@@ -282,7 +256,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                 //.withDifferenceEvaluator(DifferenceEvaluators.chain(DifferenceEvaluators.Default, versionDifferenceEvaluator))
                 .withDifferenceEvaluator(versionDifferenceEvaluator)
                 .build();
-        //System.out.println("\n\n\n\n DIFFERENCES! \n\n\n\n");
         return diff;
     }
 
@@ -347,11 +320,9 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 
         //calculate all diffs.
         final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
-        //System.out.println("hier");
         if (useRegex) {
             //calculate diffs to be excluded from the output.
             Diff versionDiffs = getVersionDiffsOnly(file1, file2);
-            System.out.println("hier falls useRegex==true");
             //bug/ feature in library: empty deltas are shown, too.
             List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
             for (Delta delta : patch.getDeltas()) {
@@ -391,10 +362,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                 if (originalLines.isEmpty() && revisedLines.isEmpty()) {
                     //remove the delta from the list.
                     deltasToBeRemovedAfterTheMainLoop.add(delta);
-                } else {
-                    System.out.println("originalLines or revisedLines delta was not empty?: \n   ori: " + originalLines.toString()
-                            + "\n   rev: " + revisedLines.toString());
-
                 }
                 delta.getOriginal().setLines(originalLines);
                 delta.getRevised().setLines(revisedLines);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -317,12 +317,13 @@ public abstract class JobConfigHistoryBaseAction implements Action {
     protected final String getDiffAsString(final File file1, final File file2, final String[] file1Lines,
                                            final String[] file2Lines, final boolean useRegex) {
 
-        //calculate diffs to be excluded from the output.
-        Diff versionDiffs = getVersionDiffsOnly(file1, file2);
+
         //calculate all diffs.
         final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
-        System.out.println("hier");
+        //System.out.println("hier");
         if (useRegex) {
+            //calculate diffs to be excluded from the output.
+            Diff versionDiffs = getVersionDiffsOnly(file1, file2);
             System.out.println("hier falls useRegex==true");
             //bug/ feature in library: empty deltas are shown, too.
             List<Delta> deltasToBeRemovedAfterTheMainLoop = new LinkedList<Delta>();
@@ -376,11 +377,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 
         final List<String> unifiedDiff = DiffUtils.generateUnifiedDiff(file1.getPath(), file2.getPath(),
                 Arrays.asList(file1Lines), patch, 3);
-
-        System.out.println("FINAL DIFF(useRegex: " + useRegex  + "):\n\n");
-        for (String str : unifiedDiff) {
-            System.out.println(str);
-        }
 
         return StringUtills.join(unifiedDiff, "\n") + "\n";
     }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -198,7 +198,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * @return Nice and clean diff as list of single Lines. if reading one of the
      * config files does not succeed.
      */
-    public final List<Line> getDiffLines(List<String> diffLines) throws IOException {
+    public final List<Line> getDiffLines(List<String> diffLines) {
         return new GetDiffLines(diffLines).get();
     }
 
@@ -379,17 +379,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
                 Arrays.asList(file1Lines), patch, 3);
 
         return StringUtills.join(unifiedDiff, "\n") + "\n";
-    }
-
-    private static String stringArrayToString(String[] arr) {
-        String result = "";
-        for (int i = 0; i < arr.length; ++i) {
-            result += arr[i];
-            if (i < arr.length - 1) {
-                result += "\n";
-            }
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -217,16 +217,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 			final String[] file2Lines, boolean useRegex, final String ignoredLinesPattern) {
 		final Patch patch = DiffUtils.diff(Arrays.asList(file1Lines), Arrays.asList(file2Lines));
 
-		/*
-		 * patch.getDeltas().stream().filter( new Predicate<Delta>() {
-		 *
-		 * @Override public boolean test(Delta t) { return whether one of the lines
-		 * matches the regex. return !(t.getOriginal().toString().matches(ignoreRegex)
-		 * || t.getRevised().toString().matches(ignoreRegex)); }
-		 *
-		 * });
-		 */
-
 		//TODO figure out something better than the bool-solution
 		if (useRegex) {
 			//bug in library: empty deltas are shown, too.
@@ -240,12 +230,6 @@ public abstract class JobConfigHistoryBaseAction implements Action {
 				System.out.println("Original Lines: " + originalLines);
 				System.out.println("Revised Lines: " +revisedLines);
 				//--------------------------------------------------------------------------------------------------------------\DEBUG
-				/*
-				 * if (originalLines.size() != revisedLines.size()) { //TODO: find better
-				 * exception. throw new
-				 * IOException("Delta line numbers differ (original vs revised. This should not be possible."
-				 * ); }
-				 */
 				for (int line = 0; line < Math.max(originalLines.size(), revisedLines.size()); ++line) {
 					// TODO: this is crappy, O(n) if not ArrayList, change that.
 					int oriLinesSize = originalLines.size();

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -458,9 +458,4 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		return new Api(this);
 	}
 
-	//TEST AREA ####################################################################################################################
-
-
-
-
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -463,7 +463,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	/**
 	 * Action when 'Show / hide Version Changes' button in showDiffFiles.jelly is pressed:
 	 * Reloads the page with "showVersionDiffs" parameter inversed.
-	 * 
+	 *
 	 * @param req
 	 * 		StaplerRequest created by pressing the button
 	 * @param rsp
@@ -479,22 +479,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
 		//System.out.println("---- OLD REQUEST PARAM: " + req.getParameter("showVersionDiffs")+ ", NEW REQUEST param: " + showVersionDiffs);
 		//System.out.println("---- old param: " + Boolean.getBoolean(getShowVersionDiffs()) +", NEW parameter: " + !Boolean.getBoolean(getShowVersionDiffs()));
-		rsp.sendRedirect("showDiffFiles?" + "timestamp1=" + timestamp1 
-				+ "&timestamp2=" + timestamp2 + "&showVersionDiffs=" + showVersionDiffs);		
+		rsp.sendRedirect("showDiffFiles?" + "timestamp1=" + timestamp1
+				+ "&timestamp2=" + timestamp2 + "&showVersionDiffs=" + showVersionDiffs);
 	}
-	
-	/** 
-	 * Get the current request's 'showVersionDiffs'-parameter. If there is none, "True" is returned.
-	 * 
-	 * @return 
-	 * 		<b>true</b> if the current request has set this parameter to true or not at all.
-	 *		<br>
-	 * 		<b>false</b> else
-	 */
-	public String getShowVersionDiffs() {
-		String showVersionDiffs = (String) (this.getRequestParameter("showVersionDiffs"));
-		return (showVersionDiffs  == null) ? "True" : showVersionDiffs;
-	}
+
 	
 	/**
 	 * For tests.

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -385,15 +385,16 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 * Filters lines that match the <i>ignoredLinesPattern</i> if wanted.
 	 * 
 	 * @param useRegex determines whether lines that match the
-	 * 		<i>ignoredLinesPattern</i> shall be hidden or not.
-	 * @param ignoredLinesPattern the regular expression 
-	 * 		which the lines are matched against.
+	 *                 <i>ignoredLinesPattern</i> shall be hidden or not.
+	 * @param ignoredLinesPattern the regular expression
+	 *                            which the lines are matched against.
 	 * @param ignoredDiffPattern the regular expression which
-	 *                              the difference of two lines are matched against.
+	 *                           the difference of two lines are matched against.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern, String ignoredDiffPattern) throws IOException {
+	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern,
+									 String ignoredDiffPattern) throws IOException {
 		if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
 			checkConfigurePermission();
 			return null;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -372,8 +372,12 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 												"(" + namePatternWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
 												+ " " + pluginNameVersionPattern 									//  plugin="test-test-test@1.2.3
 												+ "(/|)" + ">";														// />
+		//TODO find a good pattern.
+		//pattern slightly differs from versionPattern
+		String ignoredDiffPattern = "[[\\d]*(\\.|)]*[\\d]*(-SNAPSHOT|)" + "\"" + "(/|)" + ">";
+		System.out.println();
 		boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
-		return getLines(hideVersionDiffs, ignoredLinesPattern);
+		return getLines(hideVersionDiffs, ignoredLinesPattern, ignoredDiffPattern);
 	}
 	
 	/**
@@ -385,10 +389,12 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 * 		<i>ignoredLinesPattern</i> shall be hidden or not.
 	 * @param ignoredLinesPattern the regular expression 
 	 * 		which the lines are matched against.
+	 * @param ignoredDiffPattern the regular expression which
+	 *                              the difference of two lines are matched against.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern) throws IOException {
+	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern, String ignoredDiffPattern) throws IOException {
 		if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
 			checkConfigurePermission();
 			return null;
@@ -404,7 +410,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		//compute the diff with respect to ignoredLinesPattern if useRegex == true
 		final String diffAsString =
 				getDiffAsString(configXml1.getFile(), configXml2.getFile(), configXml1Lines,
-				configXml2Lines, useRegex, ignoredLinesPattern);
+				configXml2Lines, useRegex, ignoredLinesPattern, ignoredDiffPattern);
 
 		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
 		return getDiffLines(diffLines);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -505,10 +505,11 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 
 	/**
 	 * Get the current request's 'showVersionDiffs'-parameter. If there is none, "True" is returned.
-	 *
-	 * @return
-	 * 		<code>true</code> if the current request has set this parameter to true or not at all.
-	 * 		<code>false</code> else
+	 * 
+	 * @return 
+	 * 		<b>true</b> if the current request has set this parameter to true or not at all.
+	 *		<br>
+	 * 		<b>false</b> else
 	 */
 	public String getShowVersionDiffs() {
 		String showVersionDiffs = (String) (this.getRequestParameter("showVersionDiffs"));

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -380,15 +380,15 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 * Takes the two timestamp request parameters and returns the diff between
 	 * the corresponding config files of this project as a list of single lines.
 	 * Filters lines that match the <i>ignoredLinesPattern</i> if wanted.
-	 *
-	 * @param usePattern determines whether lines that match the
+	 * 
+	 * @param useRegex determines whether lines that match the
 	 * 		<i>ignoredLinesPattern</i> shall be hidden or not.
-	 * @param ignoredLinesPattern the regular expression
+	 * @param ignoredLinesPattern the regular expression 
 	 * 		which the lines are matched against.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean usePattern, String ignoredLinesPattern) throws IOException {
+	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern) throws IOException {
 		if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
 			checkConfigurePermission();
 			return null;
@@ -400,15 +400,11 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final String[] configXml1Lines = configXml1.asString().split("\\n");
 		final XmlFile configXml2 = getOldConfigXml(timestamp2);
 		final String[] configXml2Lines = configXml2.asString().split("\\n");
-		
-		//check if the regex shall be used
-		final String diffAsString = 
-				usePattern
-				? getDiffAsString(configXml1.getFile(),
-				//configXml2.getFile(), configXml1Lines, configXml2Lines, true, "[.*]") 
-				configXml2.getFile(), configXml1Lines, configXml2Lines, true, ignoredLinesPattern)
-				: getDiffAsString(configXml1.getFile(),
-						configXml2.getFile(), configXml1Lines, configXml2Lines);
+
+		//compute the diff with respect to ignoredLinesPattern if useRegex == true
+		final String diffAsString =
+				getDiffAsString(configXml1.getFile(), configXml2.getFile(), configXml1Lines,
+				configXml2Lines, useRegex, ignoredLinesPattern);
 
 		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
 		return getDiffLines(diffLines);
@@ -499,11 +495,11 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
 		//System.out.println("---- OLD REQUEST PARAM: " + req.getParameter("showVersionDiffs")+ ", NEW REQUEST param: " + showVersionDiffs);
 		//System.out.println("---- old param: " + Boolean.getBoolean(getShowVersionDiffs()) +", NEW parameter: " + !Boolean.getBoolean(getShowVersionDiffs()));
-		rsp.sendRedirect("showDiffFiles?" + "timestamp1=" + timestamp1
+		rsp.sendRedirect("showDiffFiles?" + "timestamp1=" + timestamp1 
 				+ "&timestamp2=" + timestamp2 + "&showVersionDiffs=" + showVersionDiffs);		
 	}
-
-	/**
+	
+	/** 
 	 * Get the current request's 'showVersionDiffs'-parameter. If there is none, "True" is returned.
 	 * 
 	 * @return 
@@ -515,7 +511,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		String showVersionDiffs = (String) (this.getRequestParameter("showVersionDiffs"));
 		return (showVersionDiffs  == null) ? "True" : showVersionDiffs;
 	}
-
+	
 	/**
 	 * For tests.
 	 *

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -354,10 +354,12 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 *
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException
+	 *
 	 *             If diff doesn't work or xml files can't be read.
 	 */
 	public final List<Line> getLines() throws IOException {
 
+		//TODO perhaps make this more general
 		//mustn't end with dot.
 		String whitespacePattern = 				"\\s*";
 		String namePatternWithDotPattern = 		"[[\\w]+[\\.]?]*[\\w]+";
@@ -368,14 +370,15 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		String pluginNameVersionPattern = 		"plugin=\"" + namePatternWithHyphenPattern + "@" + versionPattern +"\"";
 
 		// example:    <(test.test) plugin="test-test-test@1.2.3"/>
-		String ignoredLinesPattern = 			whitespacePattern + "<" + 											// <
+		final String ignoredLinesPattern = 			whitespacePattern + "<" + 										// <
 												"(" + namePatternWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
 												+ " " + pluginNameVersionPattern 									//  plugin="test-test-test@1.2.3
-												+ "(/|)" + ">";														// />
-		//TODO find a good pattern.
+												+ "(/|)" + ">"														// />
+												+ whitespacePattern;
+
 		//pattern slightly differs from versionPattern
-		String ignoredDiffPattern = "[[\\d]*(\\.|)]*[\\d]*(-SNAPSHOT|)" + "\"" + "(/|)" + ">";
-		boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
+		final String ignoredDiffPattern = "[[\\d]*(\\.|)]*[\\d]*(-SNAPSHOT|)" + "\"" + "(/|)" + ">";
+		final boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
 		return getLines(hideVersionDiffs, ignoredLinesPattern, ignoredDiffPattern);
 	}
 	

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -358,28 +358,8 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 *             If diff doesn't work or xml files can't be read.
 	 */
 	public final List<Line> getLines() throws IOException {
-
-		//TODO perhaps make this more general? especially the name patterns..
-		//mustn't end with dot.
-		String whitespacePattern = 				"\\s*";
-		String nameWithDotPattern = 			"[[\\w]+[\\.]?]*[\\w]+";
-		String scmClassPattern = 				"scm class=\"" + nameWithDotPattern + "\"";
-		String nameWithHyphenPattern = 			"[[\\w]+[-]?]*[\\w]+";
-		//mustn't end with dot.
-		String versionPattern = 				"[[\\d]+(\\.|)]*[\\d]+(-SNAPSHOT|)";
-		String pluginNameVersionPattern = 		"plugin=\"" + nameWithHyphenPattern + "@" + versionPattern +"\"";
-		
-		// example:    <(test.test) plugin="test-test-test@1.2.3"/>
-		final String ignoredLinesPattern = 		whitespacePattern + "<" + 									// <
-												"(" + nameWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
-												+ " " + pluginNameVersionPattern 							//  plugin="test-test-test@1.2.3
-												+ "(/|)" + ">"												// />
-												+ whitespacePattern;
-
-		//pattern slightly differs from versionPattern
-		final String ignoredDiffPattern = "[[\\d]*(\\.|)]*[\\d]*(-SNAPSHOT|)" + "\"" + "(/|)" + ">";
 		final boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
-		return getLines(hideVersionDiffs, ignoredLinesPattern, ignoredDiffPattern);
+		return getLines(hideVersionDiffs);
 	}
 	
 	/**
@@ -389,15 +369,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 * 
 	 * @param useRegex determines whether lines that match the
 	 *                 <i>ignoredLinesPattern</i> shall be hidden or not.
-	 * @param ignoredLinesPattern the regular expression
-	 *                            which the lines are matched against.
-	 * @param ignoredDiffPattern the regular expression which
-	 *                           the difference of two lines are matched against.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean useRegex, String ignoredLinesPattern,
-									 String ignoredDiffPattern) throws IOException {
+	public final List<Line> getLines(boolean useRegex) throws IOException {
 		if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
 			checkConfigurePermission();
 			return null;
@@ -413,7 +388,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		//compute the diff with respect to ignoredLinesPattern if useRegex == true
 		final String diffAsString =
 				getDiffAsString(configXml1.getFile(), configXml2.getFile(), configXml1Lines,
-				configXml2Lines, useRegex, ignoredLinesPattern, ignoredDiffPattern);
+				configXml2Lines, useRegex);
 
 		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
 		return getDiffLines(diffLines);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -364,20 +364,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		}
 		final String timestamp1 = getRequestParameter("timestamp1");
 		final String timestamp2 = getRequestParameter("timestamp2");
-		
-		final XmlFile configXml1 = getOldConfigXml(timestamp1);
-		final String[] configXml1Lines = configXml1.asString().split("\\n");
-		final XmlFile configXml2 = getOldConfigXml(timestamp2);
-		final String[] configXml2Lines = configXml2.asString().split("\\n");
-
-		//compute the diff with respect to ignoredLinesPattern if hideVersionDiffs == true
-		final String diffAsString =
-				getDiffAsString(configXml1.getFile(), configXml2.getFile(), configXml1Lines,
-				configXml2Lines, hideVersionDiffs);
-
-		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
-		return getDiffLines(diffLines);
-		
+		return getLines(getOldConfigXml(timestamp1), getOldConfigXml(timestamp2), hideVersionDiffs);
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -375,7 +375,6 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		//TODO find a good pattern.
 		//pattern slightly differs from versionPattern
 		String ignoredDiffPattern = "[[\\d]*(\\.|)]*[\\d]*(-SNAPSHOT|)" + "\"" + "(/|)" + ">";
-		System.out.println();
 		boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
 		return getLines(hideVersionDiffs, ignoredLinesPattern, ignoredDiffPattern);
 	}

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -347,20 +347,6 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		// no previous entry found
 		return timestamp;
 	}
-
-	/**
-	 * Takes the two timestamp request parameters and returns the diff between
-	 * the corresponding config files of this project as a list of single lines.
-	 * Filters lines that match the pattern described in the code if wanted.
-	 *
-	 * @return Differences between two config versions as list of lines.
-	 * @throws IOException
-	 *             If diff doesn't work or xml files can't be read.
-	 */
-	public final List<Line> getLines() throws IOException {
-		final boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
-		return getLines(hideVersionDiffs);
-	}
 	
 	/**
 	 * Takes the two timestamp request parameters and returns the diff between
@@ -477,10 +463,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final String timestamp1 = req.getParameter("timestamp1");
 		final String timestamp2 = req.getParameter("timestamp2");
 		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
-		//System.out.println("---- OLD REQUEST PARAM: " + req.getParameter("showVersionDiffs")+ ", NEW REQUEST param: " + showVersionDiffs);
-		//System.out.println("---- old param: " + Boolean.getBoolean(getShowVersionDiffs()) +", NEW parameter: " + !Boolean.getBoolean(getShowVersionDiffs()));
-		rsp.sendRedirect("showDiffFiles?" + "timestamp1=" + timestamp1
-				+ "&timestamp2=" + timestamp2 + "&showVersionDiffs=" + showVersionDiffs);
+		rsp.sendRedirect("showDiffFiles?"
+				+ "timestamp1=" + timestamp1
+				+ "&timestamp2=" + timestamp2
+				+ "&showVersionDiffs=" + showVersionDiffs);
 	}
 
 	

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -372,8 +372,8 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 												"(" + namePatternWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
 												+ " " + pluginNameVersionPattern 									//  plugin="test-test-test@1.2.3
 												+ "(/|)" + ">";														// />
-
-		return getLines(Boolean.parseBoolean(getShowVersionDiffs()), ignoredLinesPattern);
+		boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
+		return getLines(hideVersionDiffs, ignoredLinesPattern);
 	}
 	
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -351,29 +351,29 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	/**
 	 * Takes the two timestamp request parameters and returns the diff between
 	 * the corresponding config files of this project as a list of single lines.
+	 * Filters lines that match the pattern described in the code if wanted.
 	 *
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException
-	 *
 	 *             If diff doesn't work or xml files can't be read.
 	 */
 	public final List<Line> getLines() throws IOException {
 
-		//TODO perhaps make this more general
+		//TODO perhaps make this more general? especially the name patterns..
 		//mustn't end with dot.
 		String whitespacePattern = 				"\\s*";
-		String namePatternWithDotPattern = 		"[[\\w]+[\\.]?]*[\\w]+";
-		String scmClassPattern = 				"scm class=\"" + namePatternWithDotPattern + "\"";
-		String namePatternWithHyphenPattern = 	"[[\\w]+[-]?]*[\\w]+";
+		String nameWithDotPattern = 			"[[\\w]+[\\.]?]*[\\w]+";
+		String scmClassPattern = 				"scm class=\"" + nameWithDotPattern + "\"";
+		String nameWithHyphenPattern = 			"[[\\w]+[-]?]*[\\w]+";
 		//mustn't end with dot.
 		String versionPattern = 				"[[\\d]+(\\.|)]*[\\d]+(-SNAPSHOT|)";
-		String pluginNameVersionPattern = 		"plugin=\"" + namePatternWithHyphenPattern + "@" + versionPattern +"\"";
-
+		String pluginNameVersionPattern = 		"plugin=\"" + nameWithHyphenPattern + "@" + versionPattern +"\"";
+		
 		// example:    <(test.test) plugin="test-test-test@1.2.3"/>
-		final String ignoredLinesPattern = 			whitespacePattern + "<" + 										// <
-												"(" + namePatternWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
-												+ " " + pluginNameVersionPattern 									//  plugin="test-test-test@1.2.3
-												+ "(/|)" + ">"														// />
+		final String ignoredLinesPattern = 		whitespacePattern + "<" + 									// <
+												"(" + nameWithDotPattern + "|" + scmClassPattern + ")" 		// (test.test)
+												+ " " + pluginNameVersionPattern 							//  plugin="test-test-test@1.2.3
+												+ "(/|)" + ">"												// />
 												+ whitespacePattern;
 
 		//pattern slightly differs from versionPattern

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -353,12 +353,11 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	 * the corresponding config files of this project as a list of single lines.
 	 * Filters lines that match the <i>ignoredLinesPattern</i> if wanted.
 	 * 
-	 * @param useRegex determines whether lines that match the
-	 *                 <i>ignoredLinesPattern</i> shall be hidden or not.
+	 * @param hideVersionDiffs determines whether version diffs shall be shown or not.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean useRegex) throws IOException {
+	public final List<Line> getLines(boolean hideVersionDiffs) throws IOException {
 		if (!hasConfigurePermission() && !hasReadExtensionPermission()) {
 			checkConfigurePermission();
 			return null;
@@ -371,10 +370,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final XmlFile configXml2 = getOldConfigXml(timestamp2);
 		final String[] configXml2Lines = configXml2.asString().split("\\n");
 
-		//compute the diff with respect to ignoredLinesPattern if useRegex == true
+		//compute the diff with respect to ignoredLinesPattern if hideVersionDiffs == true
 		final String diffAsString =
 				getDiffAsString(configXml1.getFile(), configXml2.getFile(), configXml1Lines,
-				configXml2Lines, useRegex);
+				configXml2Lines, hideVersionDiffs);
 
 		final List<String> diffLines = Arrays.asList(diffAsString.split("\n"));
 		return getDiffLines(diffLines);
@@ -445,31 +444,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 		final String timestamp = req.getParameter("timestamp");
 		rsp.sendRedirect("restoreQuestion?timestamp=" + timestamp);
 	}
-	
-	/**
-	 * Action when 'Show / hide Version Changes' button in showDiffFiles.jelly is pressed:
-	 * Reloads the page with "showVersionDiffs" parameter inversed.
-	 *
-	 * @param req
-	 * 		StaplerRequest created by pressing the button
-	 * @param rsp
-	 * 		Outgoing StaplerResponse
-	 * @throws IOException
-	 * 		If XML file can't be read
-	 */
-	public final void doToggleShowHideVersionDiffs(StaplerRequest req,
-			StaplerResponse rsp) throws IOException {
-		//simply reload current page.
-		final String timestamp1 = req.getParameter("timestamp1");
-		final String timestamp2 = req.getParameter("timestamp2");
-		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
-		rsp.sendRedirect("showDiffFiles?"
-				+ "timestamp1=" + timestamp1
-				+ "&timestamp2=" + timestamp2
-				+ "&showVersionDiffs=" + showVersionDiffs);
-	}
 
-	
 	/**
 	 * For tests.
 	 *
@@ -482,4 +457,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 	public Api getApi() {
 		return new Api(this);
 	}
+
+	//TEST AREA ####################################################################################################################
+
+
+
+
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -320,20 +320,6 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
 	}
 
 	/**
-	 * Returns the diff between two config files as a list of single lines.
-	 * Takes the two timestamps and the name of the system property or the
-	 * deleted job from the url parameters.
-	 *
-	 * @return Differences between two config versions as list of lines.
-	 * @throws IOException
-	 *             If diff doesn't work or xml files can't be read.
-	 */
-	public final List<Line> getLines() throws IOException {
-		final boolean hideVersionDiffs = !Boolean.parseBoolean(getShowVersionDiffs());
-		return getLines(hideVersionDiffs);
-	}
-
-	/**
 	 * Takes the two timestamp request parameters and returns the diff between
 	 * the corresponding config files of this project as a list of single lines.
 	 * Filters lines that contain plugin version infomation.
@@ -563,19 +549,6 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
 				+ "name="			+ name
 				+ "&timestamp1=" 	+ timestamp1
 				+ "&timestamp2=" 	+ timestamp2 + "&showVersionDiffs=" + showVersionDiffs);
-	}
-
-	/**
-	 * Get the current request's 'showVersionDiffs'-parameter. If there is none, "True" is returned.
-	 *
-	 * @return
-	 * 		<b>true</b> if the current request has set this parameter to true or not at all.
-	 *		<br>
-	 * 		<b>false</b> else
-	 */
-	public String getShowVersionDiffs() {
-		String showVersionDiffs = (String) (this.getRequestParameter("showVersionDiffs"));
-		return (showVersionDiffs  == null) ? "True" : showVersionDiffs;
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -324,30 +324,31 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
 	 * the corresponding config files of this project as a list of single lines.
 	 * Filters lines that contain plugin version infomation.
 	 *
-	 * @param useRegex determines whether lines that match the
+	 * @param hideVersionDiffs determines whether lines that match the
 	 *                 <i>ignoredLinesPattern</i> shall be hidden or not.
 	 * @return Differences between two config versions as list of lines.
 	 * @throws IOException If diff doesn't work or xml files can't be read.
 	 */
-	public final List<Line> getLines(boolean useRegex) throws IOException {
+	public final List<Line> getLines(boolean hideVersionDiffs) throws IOException {
 		final String name = getRequestParameter("name");
 		if ((name.contains(DeletedFileFilter.DELETED_MARKER)
 				&& hasJobConfigurePermission()) || hasConfigurePermission()) {
 			final String timestamp1 = getRequestParameter("timestamp1");
 			final String timestamp2 = getRequestParameter("timestamp2");
 
-			final XmlFile configXml1 = getOldConfigXml(name, timestamp1);
+			/*final XmlFile configXml1 = getOldConfigXml(name, timestamp1);
 			final String[] configXml1Lines = configXml1.asString().split("\\n");
 			final XmlFile configXml2 = getOldConfigXml(name, timestamp2);
 			final String[] configXml2Lines = configXml2.asString().split("\\n");
 
-			//compute the diff with respect to ignoredLinesPattern if useRegex == true
+			//compute the diff with respect to ignoredLinesPattern if hideVersionDiffs == true
 			final String diffAsString = getDiffAsString(configXml1.getFile(),
-					configXml2.getFile(), configXml1Lines, configXml2Lines, useRegex);
+					configXml2.getFile(), configXml1Lines, configXml2Lines, hideVersionDiffs);
 
 			final List<String> diffLines = Arrays
 					.asList(diffAsString.split("\n"));
-			return getDiffLines(diffLines);
+			return getDiffLines(diffLines);*/
+			return getLines(getOldConfigXml(name, timestamp1), getOldConfigXml(name, timestamp2), hideVersionDiffs);
 		} else {
 			return Collections.emptyList();
 		}
@@ -513,7 +514,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
 	/**
 	 * Action when 'restore' button in history.jelly is pressed. Gets required
 	 * parameter and forwards to restoreQuestion.jelly.
-	 * 
+	 *
 	 * @param req
 	 *            StaplerRequest created by pressing the button
 	 * @param rsp

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -528,30 +528,6 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
 	}
 
 	/**
-	 * Action when 'Show / hide Version Changes' button in showDiffFiles.jelly is pressed:
-	 * Reloads the page with "showVersionDiffs" parameter inversed.
-	 *
-	 * @param req
-	 * 		StaplerRequest created by pressing the button
-	 * @param rsp
-	 * 		Outgoing StaplerResponse
-	 * @throws IOException
-	 * 		If XML file can't be read
-	 */
-	public final void doToggleShowHideVersionDiffs(StaplerRequest req,
-												   StaplerResponse rsp) throws IOException {
-		//simply reload current page.
-		final String timestamp1 = req.getParameter("timestamp1");
-		final String timestamp2 = req.getParameter("timestamp2");
-		final String name = req.getParameter("name");
-		final String showVersionDiffs = Boolean.toString(!Boolean.parseBoolean(req.getParameter("showVersionDiffs")));
-		rsp.sendRedirect("showDiffFiles?"
-				+ "name="			+ name
-				+ "&timestamp1=" 	+ timestamp1
-				+ "&timestamp2=" 	+ timestamp2 + "&showVersionDiffs=" + showVersionDiffs);
-	}
-
-	/**
 	 * For tests.
 	 *
 	 * @return historyDao

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -20,6 +20,26 @@
               <j:set var="next2" value="${it.getNextTimestamp(2)}"/>
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
+              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
+
+              <!-- Button for showing/ hiding version diffs in the shown Diff.-->
+              <j:choose>
+                <j:when test="${showVersionDiffs}">
+                  <f:form method="post"
+                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          name="showHideVersionDiffsForm">
+                    <f:submit value="${%Hide Version Changes}" />
+                  </f:form>
+                </j:when>
+                <j:otherwise>
+                  <f:form method="post"
+                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          name="showHideVersionDiffsForm">
+                    <f:submit value="${%Show Version Changes}" />
+                  </f:form>
+                </j:otherwise>
+              </j:choose>
+
               <table style="width:100%;">
                 <thead>
                   <tr>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -20,25 +20,27 @@
               <j:set var="next2" value="${it.getNextTimestamp(2)}"/>
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
-              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
 
-              <!-- Button for showing/ hiding version diffs in the shown Diff.-->
-              <j:choose>
-                <j:when test="${showVersionDiffs}">
-                  <f:form method="post"
-                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-                          name="showHideVersionDiffsForm">
-                    <f:submit value="${%Hide Version Changes}" />
-                  </f:form>
-                </j:when>
-                <j:otherwise>
-                  <f:form method="post"
-                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-                          name="showHideVersionDiffsForm">
-                    <f:submit value="${%Show Version Changes}" />
-                  </f:form>
-                </j:otherwise>
-              </j:choose>
+              <script>
+                var showVersionDiffsJs = true;
+
+                function toggleShowHideVersionDiffsJs() {
+                showVersionDiffsJs = !showVersionDiffsJs;
+                if (showVersionDiffsJs === true) {
+                document.getElementById("tbody_versionDiffsShown").style.display = '';
+                document.getElementById("tbody_versionDiffsHidden").style.display = 'none';
+
+                document.getElementById("showHideVersionDiffsJsButton").value = "Hide Version Changes";
+                } else {
+                document.getElementById("tbody_versionDiffsShown").style.display = 'none';
+                document.getElementById("tbody_versionDiffsHidden").style.display = '';
+
+                document.getElementById("showHideVersionDiffsJsButton").value = "Show Version Changes";
+                }
+                }
+
+              </script>
+              <input id="showHideVersionDiffsJsButton" type="button" value="Hide Version Changes" onClick="toggleShowHideVersionDiffsJs();"/>
 
               <table style="width:100%;">
                 <thead>
@@ -81,7 +83,10 @@
                     </td>             
                   </tr>
                 </thead>
-                <tbody style="outline: 1pt solid #B2B2B2;">
+
+                <!-- The following 2 tbodys are switched via a js button-->
+                <!-- First is default and shows version diffs, second doesn't.-->
+                <tbody style="outline: 1pt solid #B2B2B2; display:''" id="tbody_versionDiffsShown">
                   <j:choose>
                     <j:when test="${it.getLines().size() == 0}">
                       <tr>
@@ -91,7 +96,7 @@
                       </tr>
                     </j:when>
                   <j:otherwise>
-                    <j:forEach items="${it.getLines()}" var="line">
+                    <j:forEach items="${it.getLines(false)}" var="line">
                       <tr>
                         <j:choose>
                           <j:when test="${line.skipping}">
@@ -112,6 +117,39 @@
                     </j:otherwise>
                   </j:choose>
                 </tbody>
+
+                <tbody style="outline: 1pt solid #B2B2B2; display:none" id="tbody_versionDiffsHidden">
+                  <j:choose>
+                    <j:when test="${it.getLines().size() == 0}">
+                      <tr>
+                        <td colspan="4">
+                          <p>${%No lines changed}</p>
+                        </td>
+                      </tr>
+                    </j:when>
+                    <j:otherwise>
+                      <j:forEach items="${it.getLines(true)}" var="line">
+                        <tr>
+                          <j:choose>
+                            <j:when test="${line.skipping}">
+                              <th class="lineNum">...</th>
+                              <td class="skipping"></td>
+                              <th class="lineNum">...</th>
+                              <td class="skipping"></td>
+                            </j:when>
+                            <j:otherwise>
+                              <th class="lineNum">${line.left.lineNumber}</th>
+                              <td class="${line.left.cssClass}"><pre><j:out value="${line.left.text}"/></pre></td>
+                              <th class="lineNum">${line.right.lineNumber}</th>
+                              <td class="${line.right.cssClass}"><pre><j:out value="${line.right.text}"/></pre></td>
+                            </j:otherwise>
+                          </j:choose>
+                        </tr>
+                      </j:forEach>
+                    </j:otherwise>
+                  </j:choose>
+                </tbody>
+
               </table>
               <div align="middle">
                 <table>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -25,18 +25,18 @@
                 var showVersionDiffsJs = true;
 
                 function toggleShowHideVersionDiffsJs() {
-                showVersionDiffsJs = !showVersionDiffsJs;
-                if (showVersionDiffsJs === true) {
-                document.getElementById("tbody_versionDiffsShown").style.display = '';
-                document.getElementById("tbody_versionDiffsHidden").style.display = 'none';
+                  showVersionDiffsJs = !showVersionDiffsJs;
+                  if (showVersionDiffsJs === true) {
+                    document.getElementById("tbody_versionDiffsShown").style.display = '';
+                    document.getElementById("tbody_versionDiffsHidden").style.display = 'none';
 
-                document.getElementById("showHideVersionDiffsJsButton").value = "Hide Version Changes";
-                } else {
-                document.getElementById("tbody_versionDiffsShown").style.display = 'none';
-                document.getElementById("tbody_versionDiffsHidden").style.display = '';
+                    document.getElementById("showHideVersionDiffsJsButton").value = "Hide Version Changes";
+                  } else {
+                    document.getElementById("tbody_versionDiffsShown").style.display = 'none';
+                    document.getElementById("tbody_versionDiffsHidden").style.display = '';
 
-                document.getElementById("showHideVersionDiffsJsButton").value = "Show Version Changes";
-                }
+                    document.getElementById("showHideVersionDiffsJsButton").value = "Show Version Changes";
+                  }
                 }
 
               </script>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -42,7 +42,7 @@
                 }
 
               </script>
-              <input id="showHideVersionDiffsJsButton" type="button" value="Hide version diffs" onClick="toggleShowHideVersionDiffsJs();"/>
+              <input id="showHideVersionDiffsJsButton" type="button" value="Hide Version Changes" onClick="toggleShowHideVersionDiffsJs();"/>
 
               <table style="width:100%;">
                 <thead>
@@ -94,7 +94,6 @@
                   </tr>
                 </thead>
 
-
                 <!-- The following 2 tbodys are switched via a js button-->
                 <!-- First is default and shows version diffs, second doesn't.-->
                 <tbody style="outline: 1pt solid #B2B2B2; display:''" id="tbody_versionDiffsShown">
@@ -130,7 +129,7 @@
                   </j:choose>
                 </tbody>
 
-                <tbody style="outline: 1pt solid #B2B2B2; display:'none'" id="tbody_versionDiffsHidden">
+                <tbody style="outline: 1pt solid #B2B2B2; display:none" id="tbody_versionDiffsHidden">
                   <j:choose>
                     <j:when test="${it.getLines().size() == 0}">
                       <tr>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -22,51 +22,27 @@
               <j:set var="next2" value="${it.getNextTimestamp(2)}"/>
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
-              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
 
-              <!-- TEST SECTION BEGIN>
-              <g:evaluate>
-                function foo() {
-                return "Hallo, " + " test";
+              <script>
+                var showVersionDiffsJs = true;
+
+                function toggleShowHideVersionDiffsJs() {
+                  showVersionDiffsJs = !showVersionDiffsJs;
+                  if (showVersionDiffsJs === true) {
+                    document.getElementById("tbody_versionDiffsShown").style.display = '';
+                    document.getElementById("tbody_versionDiffsHidden").style.display = 'none';
+
+                    document.getElementById("showHideVersionDiffsJsButton").value = "Hide Version Changes";
+                  } else {
+                    document.getElementById("tbody_versionDiffsShown").style.display = 'none';
+                    document.getElementById("tbody_versionDiffsHidden").style.display = '';
+
+                    document.getElementById("showHideVersionDiffsJsButton").value = "Show Version Changes";
+                  }
                 }
-              </g:evaluate>
-              <g:set var="jaja" value="geht nicht."/>
 
-              <p>
-                Test von Evaluate: ${jaja}
-              </p>
-
-
-
-              <a href="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}">${%TEST ob des was anderes tut.}</a> <br />
-
-              < TEST SECTION END-->
-
-              <j:choose>
-              	<j:when test="${showVersionDiffs}">
-               		<f:form method="post" 
-               			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-               			name="showHideVersionDiffsForm">
-              			<f:submit value="${%Hide Version Changes}" />
-              		</f:form>
-              	</j:when>
-              	<j:otherwise>
-              		<f:form method="post" 
-              			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-              			name="showHideVersionDiffsForm">
-              			<f:submit value="${%Show Version Changes}" />
-              		</f:form>
-              	</j:otherwise>
-              </j:choose>
-              <!-- this sucks. //TODO translate this to groovy and use that.
-              <f:radio name="testRadio" title="TESTRADIO" value=""/>
-              <f:optionalBlock name="testBlock" title="Test-OptionalBlock" checked="testRadio"
-                description="Test Description: oegnapogn">
-
-
-
-              </f:optionalBlock>
-              -->
+              </script>
+              <input id="showHideVersionDiffsJsButton" type="button" value="Hide version diffs" onClick="toggleShowHideVersionDiffsJs();"/>
 
               <table style="width:100%;">
                 <thead>
@@ -117,23 +93,28 @@
                     </td>
                   </tr>
                 </thead>
-                <tbody style="outline: 1pt solid #B2B2B2;">
-              <j:choose>
-                <j:when test="${it.getLines().size() == 0}">
+
+
+                <!-- The following 2 tbodys are switched via a js button-->
+                <!-- First is default and shows version diffs, second doesn't.-->
+                <tbody style="outline: 1pt solid #B2B2B2; display:''" id="tbody_versionDiffsShown">
+                  <j:choose>
+                    <j:when test="${it.getLines().size() == 0}">
                       <tr>
                         <td colspan="4">
                           <p>${%No lines changed}</p>
                         </td>
                       </tr>
                     </j:when>
-                  <j:otherwise>
-              <j:forEach items="${it.getLines()}" var="line">
-                      <tr>
-                        <j:choose>
-                          <j:when test="${line.skipping}">
-                            <th class="lineNum">...</th>
+                    <j:otherwise>
+
+                      <j:forEach items="${it.getLines(false)}" var="line">
+                        <tr>
+                          <j:choose>
+                            <j:when test="${line.skipping}">
+                              <th class="lineNum">...</th>
                               <td class="skipping"></td>
-                            <th class="lineNum">...</th>
+                              <th class="lineNum">...</th>
                               <td class="skipping"></td>
                             </j:when>
                             <j:otherwise>
@@ -148,6 +129,43 @@
                     </j:otherwise>
                   </j:choose>
                 </tbody>
+
+                <tbody style="outline: 1pt solid #B2B2B2; display:'none'" id="tbody_versionDiffsHidden">
+                  <j:choose>
+                    <j:when test="${it.getLines().size() == 0}">
+                      <tr>
+                        <td colspan="4">
+                          <p>${%No lines changed}</p>
+                        </td>
+                      </tr>
+                    </j:when>
+                    <j:otherwise>
+                      <!-- hide version diffs-->
+                      <j:forEach items="${it.getLines(true)}" var="line">
+                        <tr>
+                          <j:choose>
+                            <j:when test="${line.skipping}">
+                              <th class="lineNum">...</th>
+                              <td class="skipping"></td>
+                              <th class="lineNum">...</th>
+                              <td class="skipping"></td>
+                            </j:when>
+                            <j:otherwise>
+                              <th class="lineNum">${line.left.lineNumber}</th>
+                              <td class="${line.left.cssClass}"><pre><j:out value="${line.left.text}"/></pre></td>
+                              <th class="lineNum">${line.right.lineNumber}</th>
+                              <td class="${line.right.cssClass}"><pre><j:out value="${line.right.text}"/></pre></td>
+                            </j:otherwise>
+                          </j:choose>
+                        </tr>
+                      </j:forEach>
+                    </j:otherwise>
+                  </j:choose>
+                </tbody>
+
+
+
+
               </table>
               <div align="middle">
                 <table>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -20,6 +20,10 @@
               <j:set var="next2" value="${it.getNextTimestamp(2)}"/>
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
+              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
+              <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" name="showHideVersionDiffs" >
+                          <f:submit value="${%Show / Hide Version Changes}" />
+                        </f:form>
               <table style="width:100%;">
                 <thead>
                   <tr>
@@ -115,8 +119,8 @@
                     <!-- Test Button:-->
                     <td>
                       
-                        <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}" name="prevEntry" >
-                          <f:submit value="${%Show/ Hide Version Changes}" />
+                        <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" name="showHideVersionDiffs" >
+                          <f:submit value="${%Show / Hide Version Changes}" />
                         </f:form>
                       
                     </td>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -25,7 +25,7 @@
               <j:choose>
               	<j:when test="${showVersionDiffs}">
                		<f:form method="post" 
-               			action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" 
+               			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
                			name="showHideVersionDiffs" 
                		>
               			<f:submit value="${%Hide Version Changes}" />
@@ -33,7 +33,7 @@
               	</j:when>
               	<j:otherwise>
               		<f:form method="post" 
-              			action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" 
+              			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
               			name="showHideVersionDiffs" 
               		>
               			<f:submit value="${%Show Version Changes}" />

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -21,11 +21,38 @@
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
               <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
-              <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" name="showHideVersionDiffs" >
-                          <f:submit value="${%Show / Hide Version Changes}" />
-                        </f:form>
+              
+              <j:choose>
+              	<j:when test="${showVersionDiffs}">
+               		<f:form method="post" 
+               			action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" 
+               			name="showHideVersionDiffs" 
+               		>
+              			<f:submit value="${%Hide Version Changes}" />
+              		</f:form>
+              	</j:when>
+              	<j:otherwise>
+              		<f:form method="post" 
+              			action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" 
+              			name="showHideVersionDiffs" 
+              		>
+              			<f:submit value="${%Show Version Changes}" />
+              		</f:form>
+              	</j:otherwise>
+              </j:choose>
+              
               <table style="width:100%;">
                 <thead>
+                  <!--
+                  <tr>
+                  	<f:checkbox name="hideVersionChangesCheckbox" title="Hide Version Changes (use the button above...)" 
+                  		tooltip="Hide the diff-lines which only consist of version changes."
+                  		onclick="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                  		checked="${showVersionDiffs}"
+                  		readonly="true"
+                  	/>
+                  </tr>
+                  -->
                   <tr>
                     <td colspan="2"> <font size="3"> Older Change </font></td>
                     <td colspan="2"> <font size="3"> Newer Change </font></td>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -1,5 +1,7 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:g="glide" xmlns:y="wasauchimmeroa4">
+
   <l:layout title="Job Configuration History" css="/plugin/jobConfigHistory/diff_highlight.css">
     <st:include it="${it.project}" page="sidepanel.jelly" />
     <l:main-panel>
@@ -22,6 +24,23 @@
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
               <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
 
+              <!-- TEST SECTION BEGIN>
+              <g:evaluate>
+                function foo() {
+                return "Hallo, " + " test";
+                }
+              </g:evaluate>
+              <g:set var="jaja" value="geht nicht."/>
+
+              <p>
+                Test von Evaluate: ${jaja}
+              </p>
+
+
+
+              <a href="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}">${%TEST ob des was anderes tut.}</a> <br />
+
+              < TEST SECTION END-->
 
               <j:choose>
               	<j:when test="${showVersionDiffs}">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -21,7 +21,8 @@
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
               <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
-              
+
+
               <j:choose>
               	<j:when test="${showVersionDiffs}">
                		<f:form method="post" 
@@ -38,7 +39,16 @@
               		</f:form>
               	</j:otherwise>
               </j:choose>
-              
+              <!-- this sucks. //TODO translate this to groovy and use that.
+              <f:radio name="testRadio" title="TESTRADIO" value=""/>
+              <f:optionalBlock name="testBlock" title="Test-OptionalBlock" checked="testRadio"
+                description="Test Description: oegnapogn">
+
+
+
+              </f:optionalBlock>
+              -->
+
               <table style="width:100%;">
                 <thead>
                   <tr>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -142,15 +142,6 @@
                         </f:form>
                       </j:if>
                     </td>
-                    Das ist kein Kommentar.
-                    <!-- Test Button:-->
-                    <td>
-                      
-                        <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}" name="showHideVersionDiffs" >
-                          <f:submit value="${%Show / Hide Version Changes}" />
-                        </f:form>
-                      
-                    </td>
                     <td>
                       <j:if test="${next1 != timestamp1}">
                         <f:form method="post" action="diffFilesPrevNext?timestamp1=${next1}&amp;timestamp2=${timestamp2}" name="nextEntry" >

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -111,6 +111,15 @@
                         </f:form>
                       </j:if>
                     </td>
+                    Das ist kein Kommentar.
+                    <!-- Test Button:-->
+                    <td>
+                      
+                        <f:form method="post" action="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}" name="prevEntry" >
+                          <f:submit value="${%Show/ Hide Version Changes}" />
+                        </f:form>
+                      
+                    </td>
                     <td>
                       <j:if test="${next1 != timestamp1}">
                         <f:form method="post" action="diffFilesPrevNext?timestamp1=${next1}&amp;timestamp2=${timestamp2}" name="nextEntry" >

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -26,16 +26,14 @@
               	<j:when test="${showVersionDiffs}">
                		<f:form method="post" 
                			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-               			name="showHideVersionDiffs" 
-               		>
+               			name="showHideVersionDiffsForm">
               			<f:submit value="${%Hide Version Changes}" />
               		</f:form>
               	</j:when>
               	<j:otherwise>
               		<f:form method="post" 
               			action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-              			name="showHideVersionDiffs" 
-              		>
+              			name="showHideVersionDiffsForm">
               			<f:submit value="${%Show Version Changes}" />
               		</f:form>
               	</j:otherwise>
@@ -43,16 +41,6 @@
               
               <table style="width:100%;">
                 <thead>
-                  <!--
-                  <tr>
-                  	<f:checkbox name="hideVersionChangesCheckbox" title="Hide Version Changes (use the button above...)" 
-                  		tooltip="Hide the diff-lines which only consist of version changes."
-                  		onclick="toggleShowHideVersionDiffs?timestamp1=${prev1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-                  		checked="${showVersionDiffs}"
-                  		readonly="true"
-                  	/>
-                  </tr>
-                  -->
                   <tr>
                     <td colspan="2"> <font size="3"> Older Change </font></td>
                     <td colspan="2"> <font size="3"> Newer Change </font></td>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
@@ -25,31 +25,38 @@
             <div>
               <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
               <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
-              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
-              <!-- Button for showing/ hiding version changes.-->
-              <j:choose>
-                <j:when test="${showVersionDiffs}">
-                  <f:form method="post"
-                          action="toggleShowHideVersionDiffs?name=${name}&amp;timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-                          name="showHideVersionDiffsForm">
-                    <f:submit value="${%Hide Version Changes}" />
-                  </f:form>
-                </j:when>
-                <j:otherwise>
-                  <f:form method="post"
-                          action="toggleShowHideVersionDiffs?name=${name}&amp;timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
-                          name="showHideVersionDiffsForm">
-                    <f:submit value="${%Show Version Changes}" />
-                  </f:form>
-                </j:otherwise>
-              </j:choose>
+
+              <script>
+                var showVersionDiffsJs = true;
+
+                function toggleShowHideVersionDiffsJs() {
+                showVersionDiffsJs = !showVersionDiffsJs;
+                if (showVersionDiffsJs === true) {
+                document.getElementById("tbody_versionDiffsShown").style.display = '';
+                document.getElementById("tbody_versionDiffsHidden").style.display = 'none';
+
+                document.getElementById("showHideVersionDiffsJsButton").value = "Hide Version Changes";
+                } else {
+                document.getElementById("tbody_versionDiffsShown").style.display = 'none';
+                document.getElementById("tbody_versionDiffsHidden").style.display = '';
+
+                document.getElementById("showHideVersionDiffsJsButton").value = "Show Version Changes";
+                }
+                }
+
+              </script>
+              <input id="showHideVersionDiffsJsButton" type="button" value="Hide Version Changes" onClick="toggleShowHideVersionDiffsJs();"/>
+
               <j:choose>
                 <j:when test="${it.getLines().size() == 0}">
                   <p>${%No lines changed}</p>
                 </j:when>
                 <j:otherwise>
-                  <table class="pane" style="width:100%">
-                    <j:forEach items="${it.getLines()}" var="line">
+
+                  <!-- The following 2 tbodys are switched via a js button-->
+                  <!-- First is default and shows version diffs, second doesn't.-->
+                  <table class="pane" style="width:100%; display:''" id="tbody_versionDiffsShown">
+                    <j:forEach items="${it.getLines(false)}" var="line">
                       <tr>
                         <j:choose>
                           <j:when test="${line.skipping}">
@@ -68,6 +75,28 @@
                       </tr>
                     </j:forEach>
                   </table>
+
+                  <table class="pane" style="width:100%; display:none" id="tbody_versionDiffsHidden">
+                    <j:forEach items="${it.getLines(true)}" var="line">
+                      <tr>
+                        <j:choose>
+                          <j:when test="${line.skipping}">
+                            <th class="lineNum">...</th>
+                            <td class="skipping"></td>
+                            <th class="lineNum">...</th>
+                            <td class="skipping"></td>
+                          </j:when>
+                          <j:otherwise>
+                            <th class="lineNum">${line.left.lineNumber}</th>
+                            <td class="${line.left.cssClass}"><pre><j:out value="${line.left.text}"/></pre></td>
+                            <th class="lineNum">${line.right.lineNumber}</th>
+                            <td class="${line.right.cssClass}"><pre><j:out value="${line.right.text}"/></pre></td>
+                          </j:otherwise>
+                        </j:choose>
+                      </tr>
+                    </j:forEach>
+                  </table>
+
                 </j:otherwise>
               </j:choose>
             </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
@@ -23,6 +23,25 @@
           </j:when>
           <j:otherwise>
             <div>
+
+              <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
+              <!-- Button for showing/ hiding version changes.-->
+              <j:choose>
+                <j:when test="${showVersionDiffs}">
+                  <f:form method="post"
+                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          name="showHideVersionDiffsForm">
+                    <f:submit value="${%Hide Version Changes}" />
+                  </f:form>
+                </j:when>
+                <j:otherwise>
+                  <f:form method="post"
+                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          name="showHideVersionDiffsForm">
+                    <f:submit value="${%Show Version Changes}" />
+                  </f:form>
+                </j:otherwise>
+              </j:choose>
               <j:choose>
                 <j:when test="${it.getLines().size() == 0}">
                   <p>${%No lines changed}</p>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/showDiffFiles.jelly
@@ -23,20 +23,21 @@
           </j:when>
           <j:otherwise>
             <div>
-
+              <j:set var="timestamp1" value="${it.getTimestamp(1)}"/>
+              <j:set var="timestamp2" value="${it.getTimestamp(2)}"/>
               <j:set var="showVersionDiffs" value="${it.getShowVersionDiffs()}"/>
               <!-- Button for showing/ hiding version changes.-->
               <j:choose>
                 <j:when test="${showVersionDiffs}">
                   <f:form method="post"
-                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          action="toggleShowHideVersionDiffs?name=${name}&amp;timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
                           name="showHideVersionDiffsForm">
                     <f:submit value="${%Hide Version Changes}" />
                   </f:form>
                 </j:when>
                 <j:otherwise>
                   <f:form method="post"
-                          action="toggleShowHideVersionDiffs?timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
+                          action="toggleShowHideVersionDiffs?name=${name}&amp;timestamp1=${timestamp1}&amp;timestamp2=${timestamp2}&amp;showVersionDiffs=${showVersionDiffs}"
                           name="showHideVersionDiffsForm">
                     <f:submit value="${%Show Version Changes}" />
                   </f:form>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/xslt/sort.xslt
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/xslt/sort.xslt
@@ -1,10 +1,10 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
 	<!-- strip whitespace -->
-	<!xsl:strip-space elements="*" />
+	<xsl:strip-space elements="*" />
 
 	<!-- pretty print -->
-	<!xsl:output method="xml" indent="yes" />
+	<xsl:output method="xml" indent="yes" />
 
 	<!-- sort tags -->
 	<xsl:template match="node()|@*">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/xslt/sort.xslt
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/xslt/sort.xslt
@@ -1,10 +1,10 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
 	<!-- strip whitespace -->
-	<xsl:strip-space elements="*" />
+	<!xsl:strip-space elements="*" />
 
 	<!-- pretty print -->
-	<xsl:output method="xml" indent="yes" />
+	<!xsl:output method="xml" indent="yes" />
 
 	<!-- sort tags -->
 	<xsl:template match="node()|@*">

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -107,6 +108,7 @@ public class JobConfigHistoryBaseActionIT
 			public String getIconFileName() {
 				return null;
 			}
+			public List<SideBySideView.Line> getLines(boolean useRegex) { throw new UnsupportedOperationException("Not supported yet."); }
 		};
 		return action;
 	}

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionTest.java
@@ -215,6 +215,8 @@ public class JobConfigHistoryBaseActionTest {
 			throw new UnsupportedOperationException("Not supported yet.");
 		}
 
+		public  List<SideBySideView.Line> getLines(boolean useRegex) { throw new UnsupportedOperationException("Not supported yet."); }
+
 		@Override
 		protected StaplerRequest getCurrentRequest() {
 			return staplerRequestMock;


### PR DESCRIPTION
Sometimes, diffs are bloated with (rather unimportant) information about version changes.
This feature provides a button which hides those diff lines allowing the user to see the more important
changes.