### PR TITLE
Modernize (parent pom and Jenkins)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>3.42</version>
         <relativePath />
     </parent>
 
@@ -114,12 +114,23 @@
     </developers>
 
     <properties>
+        <jenkins.version>2.60.3</jenkins.version>
         <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
         <maven-hpi-plugin.injectedTestName>InjectedIT</maven-hpi-plugin.injectedTestName>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-        <jdepend-maven-plugin.version>2.9.1</jdepend-maven-plugin.version>
+        <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
         <java.level>8</java.level>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>3.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -135,7 +146,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>2.0</version>
+            <version>3.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -331,8 +342,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <threshold>Low</threshold>

--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
@@ -49,7 +49,7 @@ public class ComputerHistoryListener extends ComputerListener {
 	
 	public ComputerHistoryListener() {
 		Jenkins jenkins = Jenkins.getInstance();
-		nodes = jenkins != null ? jenkins.getNodes() : null;
+		nodes = jenkins.getNodes();
 	}
 
 	@Override
@@ -58,8 +58,6 @@ public class ComputerHistoryListener extends ComputerListener {
 		// during class initialization. NodeList will surely be defined
 		// on the first run of this method.
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
 		if (nodes == null) {
 			nodes = jenkins.getNodes();
 		}
@@ -86,8 +84,6 @@ public class ComputerHistoryListener extends ComputerListener {
 	 */
 	private void onAdd() {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
 		for (Node node : jenkins.getNodes()) {
 			if (!nodes.contains(node) && isTracked(node)) {
 				switchHistoryDao(node).createNewNode(node);
@@ -111,8 +107,6 @@ public class ComputerHistoryListener extends ComputerListener {
 	 */
 	private void onRemove() {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
 		for (Node node : nodes) {
 			if (!jenkins.getNodes().contains(node)
 					&& isTracked(node)) {
@@ -127,8 +121,6 @@ public class ComputerHistoryListener extends ComputerListener {
 	 */
 	private void onChange() {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
 		final JobConfigHistoryStrategy hdao = PluginUtils.getHistoryDao();
 		for (Node node : jenkins.getNodes()) {
 			if (!PluginUtils.isUserExcluded(PluginUtils.getPlugin())
@@ -145,8 +137,6 @@ public class ComputerHistoryListener extends ComputerListener {
 	private void onRename() {
 		Node originalNode = null;
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
 		for (Node node : nodes) {
 			if (!jenkins.getNodes().contains(node)
 					&& isTracked(node)) {

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
@@ -204,7 +204,7 @@ public class JobConfigBadgeAction implements BuildBadgeAction, RunAction2 {
 	 */
 	String getRootUrl() {
 		Jenkins jenkins = Jenkins.getInstance();
-		return jenkins != null ? jenkins.getRootUrl() : null;
+		return jenkins.getRootUrl();
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -531,7 +531,7 @@ public class JobConfigHistory extends Plugin {
 	 */
 	protected File getJenkinsHome() {
 		Jenkins jenkins = Jenkins.getInstance();
-		return jenkins != null ? jenkins.root : null;
+		return jenkins.getRootDir();
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
@@ -70,15 +70,11 @@ public class JobConfigHistoryPurger extends PeriodicWork {
 	 * Standard constructor using instance.
 	 */
 	public JobConfigHistoryPurger() {
-		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return;
-		JobConfigHistory plugin = jenkins.getPlugin(JobConfigHistory.class);
-		assignValue(plugin, 
-				(PluginUtils.getHistoryDao(plugin, null) instanceof Purgeable
-				? (Purgeable) PluginUtils.getHistoryDao(plugin, null)
-				: null), 
-				PluginUtils.getHistoryDao(plugin, null));
+		JobConfigHistory plugin = PluginUtils.getPlugin();
+		JobConfigHistoryStrategy historyDao = PluginUtils.getAnonymousHistoryDao(plugin);
+		assignValue(plugin,
+				historyDao instanceof Purgeable ? (Purgeable) historyDao : null,
+				historyDao);
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
@@ -87,8 +87,6 @@ public class JobConfigHistorySaveableListener extends SaveableListener {
 	 */
 	HistoryDao getHistoryDao(JobConfigHistory plugin) {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return null;
 		return (COMPLETED == jenkins.getInitLevel())
 				? PluginUtils.getHistoryDao(plugin)
 				: PluginUtils.getAnonymousHistoryDao(plugin);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryStrategy.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryStrategy.java
@@ -50,7 +50,7 @@ public abstract class JobConfigHistoryStrategy
 	@SuppressWarnings("unchecked")
 	public final Descriptor<JobConfigHistoryStrategy> getDescriptor() {
 		Jenkins jenkins = Jenkins.getInstance();
-		return jenkins != null ? jenkins.getDescriptorOrDie(getClass()) : null;
+		return jenkins.getDescriptorOrDie(getClass());
 	}
 
 	/**
@@ -60,8 +60,6 @@ public abstract class JobConfigHistoryStrategy
 	 */
 	public static DescriptorExtensionList<JobConfigHistoryStrategy, JobConfigHistoryDescriptor<JobConfigHistoryStrategy>> all() {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return null;
 		return jenkins
 				.<JobConfigHistoryStrategy, JobConfigHistoryDescriptor<JobConfigHistoryStrategy>>getDescriptorList(
 						JobConfigHistoryStrategy.class);

--- a/src/main/java/hudson/plugins/jobConfigHistory/PluginUtils.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/PluginUtils.java
@@ -54,7 +54,7 @@ final public class PluginUtils {
 	 */
 	public static JobConfigHistory getPlugin() {
 		Jenkins jenkins = Jenkins.getInstance();
-		return jenkins != null ? jenkins.getPlugin(JobConfigHistory.class) : null;
+		return jenkins.getPlugin(JobConfigHistory.class);
 	}
 
 	/**
@@ -113,8 +113,6 @@ final public class PluginUtils {
 			maxHistoryEntries = 0;
 		}
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return null;
 		return new FileHistoryDao(plugin.getConfiguredHistoryRootDir(),
 				new File(jenkins.root.getPath()), user,
 				maxHistoryEntries, !plugin.getSkipDuplicateHistory());
@@ -158,11 +156,9 @@ final public class PluginUtils {
 	 */
 	public static boolean isMavenPluginAvailable() {
 		Jenkins jenkins = Jenkins.getInstance();
-		if(jenkins == null)
-			return false;
 		try {
 			Plugin plugin = jenkins.getPlugin("maven-plugin");
-			return plugin.getWrapper().isActive();
+			return plugin != null && plugin.getWrapper().isActive();
 		} catch (Exception e) {
 			return false;
 		}

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
@@ -201,7 +201,7 @@ public class JobConfigHistoryBaseActionIT
 		final HtmlPage historyPage = webClient
 				.goTo("job/" + jobName + "/" + JobConfigHistoryConsts.URLNAME);
 		final HtmlForm diffFilesForm = historyPage.getFormByName("diffFiles");
-		final HtmlPage diffPage = (HtmlPage) last(diffFilesForm.getHtmlElementsByTagName("button")).click();
+		final HtmlPage diffPage = last(diffFilesForm.getElementsByTagName("button")).click();
 		assertStringContains(diffPage.asText(), "<daysToKeep>42</daysToKeep>");
 		assertStringContains(diffPage.asText(), "<numToKeep>42</numToKeep>");
 		assertStringContains(diffPage.asText(), "<daysToKeep>47</daysToKeep>");

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectActionTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectActionTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.jobConfigHistory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -21,7 +22,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.WithPlugin;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -95,9 +95,9 @@ public class JobConfigHistoryProjectActionTest {
 	/**
 	 * Test of getIconFileName method, of class JobConfigHistoryProjectAction.
 	 */
-	@WithPlugin("maven-plugin.hpi")
 	@Test
 	public void testGetIconFileNameSaveMavenModules() {
+		assertNotNull(j.jenkins.getPlugin("maven-plugin"));
 		when(mockedMavenModule.hasPermission(AbstractProject.CONFIGURE))
 				.thenReturn(true);
 		when(mockedPlugin.getSaveModuleConfiguration()).thenReturn(true);

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootActionIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootActionIT.java
@@ -180,7 +180,7 @@ public class JobConfigHistoryRootActionIT
 					page.split("Changed").length > 2);
 
 			final HtmlForm diffFilesForm = htmlPage.getFormByName("diffFiles");
-			final HtmlPage diffPage = (HtmlPage) last(diffFilesForm.getHtmlElementsByTagName("button")).click();
+			final HtmlPage diffPage = last(diffFilesForm.getElementsByTagName("button")).click();
 			assertStringContains(diffPage.asText(), firstMessage);
 			assertStringContains(diffPage.asText(), secondMessage);
 		} catch (Exception ex) {
@@ -249,8 +249,7 @@ public class JobConfigHistoryRootActionIT
 
 		final HtmlPage htmlPage = webClient
 				.goTo(JobConfigHistoryConsts.URLNAME + "/?filter=deleted");
-		final HtmlAnchor rawLink = (HtmlAnchor) htmlPage
-				.getAnchorByText("(RAW)");
+		final HtmlAnchor rawLink = htmlPage.getAnchorByText("(RAW)");
 		final String rawPage = ((TextPage) rawLink.click()).getContent();
 		Assert.assertTrue("Verify config file is shown",
 				rawPage.contains(description));
@@ -280,7 +279,7 @@ public class JobConfigHistoryRootActionIT
 		System.out.println(historyAsXml);
 		Assert.assertTrue("History page should contain 'Deleted' entry",
 				historyAsXml.contains("Deleted"));
-		final List<HtmlAnchor> hrefs = (List<HtmlAnchor>) historyPage
+		final List<HtmlAnchor> hrefs = historyPage
 				.getByXPath("//a[contains(@href, \"configOutput?type=xml\")]");
 		Assert.assertTrue(hrefs.size() > 2);
 	}
@@ -351,7 +350,7 @@ public class JobConfigHistoryRootActionIT
 				.goTo(JobConfigHistoryConsts.URLNAME + "/?filter=deleted");
 		final HtmlAnchor restoreLink = (HtmlAnchor) htmlPage
 				.getElementById("restore");
-		final HtmlPage reallyRestorePage = (HtmlPage) restoreLink.click();
+		final HtmlPage reallyRestorePage = restoreLink.click();
 		final HtmlForm restoreForm = reallyRestorePage.getFormByName("restore");
 		final HtmlPage jobPage = submit(restoreForm, "Submit");
 		return jobPage;
@@ -373,9 +372,9 @@ public class JobConfigHistoryRootActionIT
 
 		final HtmlPage htmlPage = webClient
 				.goTo(JobConfigHistoryConsts.URLNAME + "/?filter=deleted");
-		final List<HtmlAnchor> hrefs = (List<HtmlAnchor>) htmlPage
+		final List<HtmlAnchor> hrefs = htmlPage
 				.getByXPath("//a[contains(@href, \"TestProject_deleted_\")]");
-		final HtmlPage historyPage = (HtmlPage) hrefs.get(0).click();
+		final HtmlPage historyPage = hrefs.get(0).click();
 		final HtmlPage reallyRestorePage = submit(
 				historyPage.getFormByName("forward"), "Submit");
 		final HtmlPage jobPage = submit(

--- a/src/test/java/hudson/plugins/jobConfigHistory/PluginIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/PluginIT.java
@@ -52,7 +52,6 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 		private final HtmlPage configPage;
 
 		/**
-		 * @param configPage
 		 * @throws SAXException
 		 * @throws IOException
 		 */
@@ -81,7 +80,7 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 		}
 
 		public List<HtmlAnchor> getConfigOutputLinks(final String type) {
-			final List<HtmlAnchor> hrefs = (List<HtmlAnchor>) historyPage.getByXPath(
+			final List<HtmlAnchor> hrefs = historyPage.getByXPath(
 					"//a[contains(@href, \"configOutput?type=" + type + "\")]");
 			return hrefs;
 		}
@@ -110,7 +109,7 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 		public HtmlPage getDiffPage() throws IOException {
 			final HtmlForm diffFilesForm = historyPage
 					.getFormByName("diffFiles");
-			return (HtmlPage) last(diffFilesForm.getHtmlElementsByTagName("button")).click();
+			return last(diffFilesForm.getElementsByTagName("button")).click();
 		}
 
 		public void setCheckedTimestamp1RadioButton(int index,
@@ -174,7 +173,7 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 					.getConfigOutputLinks("xml");
 			Assert.assertTrue(hrefs.size() >= 1);
 			final HtmlAnchor xmlAnchor = hrefs.get(0);
-			final XmlPage xmlPage = (XmlPage) xmlAnchor.click();
+			final XmlPage xmlPage = xmlAnchor.click();
 			assertThat(xmlPage.asXml(), containsString(firstDescription));
 		}
 		{
@@ -183,7 +182,7 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 					.getConfigOutputLinks("raw");
 			Assert.assertTrue(hrefs.size() >= 2);
 			final HtmlAnchor rawAnchor = hrefs.get(0);
-			final TextPage firstRaw = (TextPage) rawAnchor.click();
+			final TextPage firstRaw = rawAnchor.click();
 			assertThat(firstRaw.getContent(),
 					containsString(secondDescription));
 		}
@@ -195,7 +194,7 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 		final List<? extends HtmlAnchor> allXmlHRefs = allJobConfigHistoryPage
 				.getConfigOutputLinks("xml");
 		Assert.assertTrue(allXmlHRefs.size() >= 2);
-		final TextPage firstRawOfAll = (TextPage) allRawHRefs.get(0).click();
+		final TextPage firstRawOfAll = allRawHRefs.get(0).click();
 		assertThat(firstRawOfAll.getContent(),
 				containsString(secondDescription));
 		final HistoryPage historyPage = new HistoryPage();
@@ -234,13 +233,12 @@ public class PluginIT extends AbstractHudsonTestCaseDeletingInstanceDir {
 		try {
 			final HtmlPage historyPage = webClient.goTo(
 					JobConfigHistoryConsts.URLNAME + "/history?name=config");
-			final List<HtmlAnchor> allRawHRefs = (List<HtmlAnchor>) historyPage.getByXPath(
+			final List<HtmlAnchor> allRawHRefs = historyPage.getByXPath(
 					"//a[contains(@href, \"configOutput?type=raw\")]");
 			Assert.assertTrue(
 					"Check that there are at least 2 links for raw output.",
 					allRawHRefs.size() >= 2);
-			final TextPage firstRawOfAll = (TextPage) allRawHRefs.get(0)
-					.click();
+			final TextPage firstRawOfAll = allRawHRefs.get(0).click();
 			assertThat(
 					"Check that the first raw output link leads to the right target.",
 					firstRawOfAll.getContent(),


### PR DESCRIPTION
Upgrading parent pom to be up-to-date.

Upgrading Jenkins as JCasC requires at least 2.60.3.

Fixing jdepend-maven-plugin version. There is no version 2.9.1. It looks like this was a copy'n'paste error from maven-javadoc-plugin version.

Setting upper bound version for plugins via `<dependencyManagement>` to be compliant with Maven enforcer rules.

Upgrading maven-plugin so that `mvn hpi:run` runs without errors.

Use SpotBugs instead of FindBugs in reporting (see change in parent pom).

Jenkins::getInstance is now annotated with `@Nonnull`. Therefore removing the unnecessary null checks that have been detected by SpotBugs.

HtmlUnit removed/changed some methods, adapting tests to compile again.

Plugin "maven-plugin" is not required to be loaded explicitly in a test. It is loaded automatically because it is defined as dependency in pom.xml. Therefore just verifying that it is loaded is enough.