### PR TITLE
Fix Javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
                     <quiet>true</quiet>
                     <aggregate>false</aggregate>
                     <links>
-                        <link>http://docs.oracle.com/javase/6/docs/api/</link>
+                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
                         <link>http://javadoc.jenkins-ci.org/</link>
                         <link>http://stapler.kohsuke.org/apidocs/</link>
                     </links>

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
@@ -81,8 +81,8 @@ public class JobConfigHistoryPurger extends PeriodicWork {
 	 *
 	 * @param plugin
 	 *            injected plugin
-	 * @param historyDao
-	 *            injected HistoryDao
+	 * @param purgeable
+	 *            the value of purgeable
 	 * @param overviewHistoryDao
 	 *            the value of overviewHistoryDao
 	 */

--- a/src/main/java/hudson/plugins/jobConfigHistory/NonDeletedFileFilter.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/NonDeletedFileFilter.java
@@ -29,7 +29,7 @@ import java.io.FileFilter;
 /**
  * A filter to return only those directories of a file listing that do not
  * represent deleted jobs history directories, the names of which do not contain
- * {@link JobConfigHistoryConsts#DELETED_MARKER}.
+ * {@link DeletedFileFilter#DELETED_MARKER}.
  *
  * @author Mirko Friedenhagen
  */

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigBadgeActionTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigBadgeActionTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import hudson.model.Build;
@@ -92,9 +93,9 @@ public class JobConfigBadgeActionTest {
 
 	/**
 	 * Test of oldConfigsExist method, of class JobConfigBadgeAction.
-	 * 
-	 * @Test
 	 */
+	@Ignore("TODO: find out what is wrong")
+	@Test
 	public void testOldConfigsExist() {
 		when(mockedHistoryDao.hasOldRevision(mockedProject.getConfigFile(),
 				configDates[0])).thenReturn(true);

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseActionIT.java
@@ -75,7 +75,7 @@ public class JobConfigHistoryBaseActionIT
 
 	/**
 	 * Test method for
-	 * {@link hudson.plugins.jobConfigHistory.JobConfigHistoryBaseAction#getDiffFile(java.lang.String, java.lang.String)}.
+	 * {@link hudson.plugins.jobConfigHistory.JobConfigHistoryBaseAction#getDiffAsString(File, File, String[], String[])}.
 	 */
 	public void testGetDiffFileStringStringEmpty() {
 		final JobConfigHistoryBaseAction action = createJobConfigHistoryBaseAction();
@@ -83,9 +83,6 @@ public class JobConfigHistoryBaseActionIT
 				.getDiffAsString(file1, file2, new String[0], new String[0])));
 	}
 
-	/**
-	 * @return
-	 */
 	JobConfigHistoryBaseAction createJobConfigHistoryBaseAction() {
 		return new JobConfigHistoryBaseAction() {
 

--- a/src/test/java/hudson/plugins/jobConfigHistory/LazyHistoryDescrTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/LazyHistoryDescrTest.java
@@ -69,7 +69,7 @@ public class LazyHistoryDescrTest {
 	}
 
 	/**
-	 * File is not {@link HistoryDescr).
+	 * File is not {@link HistoryDescr}.
 	 */
 	@Test(expected = RuntimeException.class)
 	public void testInvalidHistoryDescr() {

--- a/src/test/java/hudson/plugins/jobConfigHistory/TUtils.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/TUtils.java
@@ -105,9 +105,7 @@ public class TUtils {
 
 	/**
 	 * A suffix {@link Matcher}, which automatically handles file separators.
-	 * The method calls {@link #endsWith(java.lang.String)} method from
-	 * CoreMatchers.
-	 * 
+	 *
 	 * @since TODO: define a version
 	 */
 	public static class FilePathSuffixMatcher implements Matcher<String> {


### PR DESCRIPTION
This makes at least `mvn site` run through again.

Still a lot of Javadoc warnings are present.