### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
@@ -21,11 +21,16 @@
         <f:textbox name="excludePattern" value="${it.excludePattern}" default="${it.defaultExcludePattern}"
            checkUrl="'${rootURL}/plugin/jobConfigHistory/checkExcludePattern?value='+escape(this.value)"/>
       </f:entry>
-      <f:entry title="${%Do not save duplicate history}" help="/plugin/jobConfigHistory/help/help-skipDuplicateHistory.html">
-        <f:checkbox name="skipDuplicateHistory" checked="${it.skipDuplicateHistory}"/>
+      <f:entry help="/plugin/jobConfigHistory/help/help-skipDuplicateHistory.html">
+        <f:checkbox name="skipDuplicateHistory"
+            title="${%Do not save duplicate history}"
+            checked="${it.skipDuplicateHistory}"/>
       </f:entry>
-      <f:entry title="${%Save Maven module configuration changes}" help="/plugin/jobConfigHistory/help/help-saveModuleConfiguration.html">
-        <f:checkbox name="saveModuleConfiguration" checked="${it.saveModuleConfiguration}"/>
+      <f:entry help="/plugin/jobConfigHistory/help/help-saveModuleConfiguration.html">
+        <f:checkbox
+            title="${%Save Maven module configuration changes}"
+            name="saveModuleConfiguration"
+            checked="${it.saveModuleConfiguration}"/>
       </f:entry>
       <f:entry title="${%Show build badges}" help="/plugin/jobConfigHistory/help/help-showBuildBadges.html">
         <f:radio name="showBuildBadges" title="${%Never}" value="never" checked="${it.getShowBuildBadges() == 'never'}"/>


### PR DESCRIPTION
[JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

The new UI looks like this:
![image](https://user-images.githubusercontent.com/2119212/64212021-0eb95300-ce76-11e9-8822-53ac96fd73f5.png)

The old UI looks like this:
![image](https://user-images.githubusercontent.com/2119212/64212116-4cb67700-ce76-11e9-8789-a20c4c624676.png)

Eventually the labels which are currently to the left of text boxes will be switched to being above them, which will reduce the amount of whitespace to the left of the checkboxes.