### PR TITLE
Fix Javadoc errors

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -330,10 +330,10 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
 
 
 	/**
-	 * Find this in the configFile:<br/>
-	 * 		&emsp; &lt;hudson.plugins.jobConfigHistory.JobLocalConfiguration plugin="jobConfigHistory@2.25-SNAPSHOT"&gt;<br/>
-	 * 		&emsp; &emsp; &lt;changeReasonComment&gt;MY_CHANGE_REASON_COMMENT&lt;/changeReasonComment&gt;<br/>
-	 * 		&emsp; &lt;/hudson.plugins.jobConfigHistory.JobLocalConfiguration&gt;<br/>
+	 * Find this in the configFile:<br>
+	 * 		&emsp; &lt;hudson.plugins.jobConfigHistory.JobLocalConfiguration plugin="jobConfigHistory@2.25-SNAPSHOT"&gt;<br>
+	 * 		&emsp; &emsp; &lt;changeReasonComment&gt;MY_CHANGE_REASON_COMMENT&lt;/changeReasonComment&gt;<br>
+	 * 		&emsp; &lt;/hudson.plugins.jobConfigHistory.JobLocalConfiguration&gt;<br>
 	 * and delete it, receiving the changeReasonComment, if present.
 	 *
 	 * @param configFile the config file

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryBaseAction.java
@@ -439,7 +439,7 @@ public abstract class JobConfigHistoryBaseAction implements Action {
      * <ul>
      *     <li>0</li>
      *     <li>maxPageNum</li>
-     *     <li>all integers in {k in [currentPageNum - PAGING_EPSILON, currentPageNum + PAGING_EPSILON] | k > 0 && k < maxPageNum}.</li>
+     *     <li>all integers in {k in [currentPageNum - PAGING_EPSILON, currentPageNum + PAGING_EPSILON] | k &gt; 0 &amp;&amp; k &lt; maxPageNum}.</li>
      * </ul>
      */
     public List<Integer> getRelevantPageNums(int currentPageNum, int maxPageNum) {

--- a/src/main/java/hudson/plugins/jobConfigHistory/OverviewHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/OverviewHistoryDao.java
@@ -58,7 +58,7 @@ public interface OverviewHistoryDao {
 	/** @return the number of configuration revision entries for a certain system config. */
 	int getJobRevisionAmount(String jobName);
 
-	/** @return the total number of configuration revision entries, excluding agent config entries <-- TODO future work. */
+	/** @return the total number of configuration revision entries, excluding agent config entries - TODO future work. */
 	int getTotalRevisionAmount();
 
 	/**


### PR DESCRIPTION
They have been found running `mvn site`.

NOTE: There are still a lot of warnings (not errors).