### PR TITLE
Upgrade parent pom and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,14 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
- 
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
-        <relativePath />
+        <version>3.56</version>
     </parent>
 
     <artifactId>jobConfigHistory</artifactId>
@@ -41,30 +40,30 @@
     <name>Jenkins Job Configuration History Plugin</name>
     <description>Saves copies of job, node and system configurations.</description>
     <url>https://wiki.jenkins.io/display/JENKINS/JobConfigHistory+Plugin</url>
-    
+
     <issueManagement>
         <system>JIRA</system>
         <url>https://issues.jenkins-ci.org/issues/?jql=project %3D Jenkins AND status in (Open, "In Progress", Reopened) AND component %3D jobconfighistory-plugin</url>
     </issueManagement>
-    
+
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/jobConfigHistory-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/jobConfigHistory-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/jobConfigHistory-plugin</url>
         <tag>HEAD</tag>
     </scm>
-    
+
     <ciManagement>
         <system>Jenkins</system>
         <url>https://ci.jenkins.io/job/plugins/job/jobConfigHistory-plugin/</url>
     </ciManagement>
-    
+
     <licenses>
         <license>
             <name>MIT License</name>
         </license>
     </licenses>
-    
+
     <developers>
         <developer>
             <id>stefanbrausch</id>
@@ -115,9 +114,9 @@
 
     <properties>
         <jenkins.version>2.138.4</jenkins.version>
-        <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
+        <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-hpi-plugin.injectedTestName>InjectedIT</maven-hpi-plugin.injectedTestName>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
         <java.level>8</java.level>
     </properties>
@@ -141,7 +140,7 @@
         <dependency>
             <groupId>io.github.java-diff-utils</groupId>
             <artifactId>java-diff-utils</artifactId>
-            <version>4.0</version>
+            <version>4.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -163,7 +162,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -174,7 +173,7 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-    
+
     <repositories>
       <repository>
         <id>repo.jenkins-ci.org</id>
@@ -187,7 +186,7 @@
         <url>https://repo.jenkins-ci.org/public/</url>
       </pluginRepository>
     </pluginRepositories>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -287,13 +286,12 @@
             </plugins>
         </pluginManagement>
     </build>
-    
+
     <reporting>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
                 <!-- Avoid hanging site generation waiting for 'http://snapshots.maven.codehaus.org/maven2' see http://jira.codehaus.org/browse/MPIR-137 -->
                 <configuration>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -368,5 +366,5 @@
             </plugin>
         </plugins>
     </reporting>
-    
+
 </project>


### PR DESCRIPTION
This is to stay up-to-date.

Specifying a version for _maven-project-info-reports-plugin_ is not required as this is already specified in the parent pom.