### PR TITLE
Support Java 11 in plugin build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.164</jenkins.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-hpi-plugin.injectedTestName>InjectedIT</maven-hpi-plugin.injectedTestName>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
According to [this](https://jenkins.io/doc/administration/requirements/jenkins-on-java-11/) documentation, increasing the jenkins core version to at least 2.164 is recommended in order to run Jenkins with Java 11.

So it is required to increase the jenkins core version in the `pom.xml` to 2.164 so that the plugin can get built with Java 11.