### PR TITLE
Fix HTTP 404 for indentation.js

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -10,7 +10,6 @@
     <!--syntax highlighting-->
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/highlight.js/styles/purebasic.css"/>
     <script src="${rootURL}/plugin/jobConfigHistory/highlight.js/highlight.pack.js"></script>
-    <script src="${rootURL}/plugin/jobConfigHistory/indentation.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 
     <st:include it="${it.project}" page="sidepanel.jelly" />


### PR DESCRIPTION
There is no such file in the code base.

It seems that the reference was accidentally added in commit 643cfdbcd8da59e842fd502d7d1432c84fe2f95d.